### PR TITLE
chore: remove VS Code settings from repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-	"editor.formatOnSave": true,
-	"editor.renderWhitespace": "all",
-	"javascript.updateImportsOnFileMove.enabled": "always",
-	"typescript.preferences.importModuleSpecifier": "relative",
-	"typescript.updateImportsOnFileMove.enabled": "always",
-}


### PR DESCRIPTION
I’d suggest removing this editor-specific file from our repo, because the editor and its settings are a matter of preference. For example, I don’t reformat on save and usually don’t render the whitespace in the editor. Having this file around creates some extra effort of always resetting its state to the one from `main`.