### PR TITLE
fix: make attraction editor work when updating attractions

### DIFF
--- a/src/components/AttractionEditor/index.tsx
+++ b/src/components/AttractionEditor/index.tsx
@@ -94,7 +94,7 @@ export default function AttractionEditor(props: Props) {
 					}));
 				}}
 				rows={4}
-				required={true}
+				required={false}
 			/>
 			<Spacer size={15} />
 			<FormField

--- a/src/components/AttractionEditor/service.ts
+++ b/src/components/AttractionEditor/service.ts
@@ -1,11 +1,11 @@
 import { AdminAttraction } from "@api/client/models/AdminAttraction";
 import { CreateAttractionRequest } from "@api/client/models/CreateAttractionRequest";
 
-function createLanguagesObject(languages: Array<string>) {
+function createLanguagesObject(languages: Array<string>, existingValues: Record<string, string> | undefined) {
 	return languages.reduce(
-		(acc, lang) => {
-			acc[lang] = "";
-			return acc;
+		(result, lang) => {
+			result[lang] = existingValues?.[lang] ?? "";
+			return result;
 		},
 		{} as Record<string, string>,
 	);
@@ -17,13 +17,13 @@ export function getInitialRequest(
 ): CreateAttractionRequest {
 	return {
 		type: "type.Attraction",
-		title: createLanguagesObject(languages),
-		displayName: createLanguagesObject(languages),
-		description: createLanguagesObject(languages),
-		pleaseNote: createLanguagesObject(languages),
-		website: "",
+		title: createLanguagesObject(languages, attraction?.title),
+		displayName: createLanguagesObject(languages, attraction?.displayName),
+		description: createLanguagesObject(languages, attraction?.description),
+		pleaseNote: createLanguagesObject(languages, attraction?.pleaseNote),
+		website: attraction?.website ?? "",
 		inLanguages: languages,
-		tags: [],
-		...attraction,
+		tags: attraction?.tags || [],
+		externalLinks: attraction?.externalLinks || [],
 	};
 }


### PR DESCRIPTION
This fixes the updating of attractions by no longer inheriting all fields from an existing attraction, but only creating the fields that are required to satisfy `CreateAttractionRequest`. This would otherwise be broken with https://github.com/technologiestiftung/kulturdaten-api/pull/63 since we’d be trying to override the `metadata` field twice (once from the request coming from the frontend and once from the new date update logic in the backend).

**Bonus fix:** The "please note" field is no longer marked as required (it’s an optional field).