### PR TITLE
refactor: migrate to new openAPI schema

### DIFF
--- a/openAPI-specs.yml
+++ b/openAPI-specs.yml
@@ -1,99 +1,121 @@
 openapi: 3.0.3
 info:
-  title: API Kulturdaten.Berlin
+  title: kulturdaten.berlin API
   description: >
-    Willkommen zur Kulturdaten.Berlin-API! Diese API ermöglicht es Ihnen, eine
-    Vielzahl von Funktionen zu nutzen, um Veranstaltungen, Kulturorte,
-    Kulturangebote und Kulturakteure in Berlin zu entdecken.
-
-    Sind Sie Kulturakteur, können Sie bequem Ihre Veranstaltungen und Kulturorte
-    verwalten.
+    *We make Berlin’s cultural diversity visible*
 
 
-    Die API ist in mehrere Bereiche gegliedert. 
+    This API provides access to reading and writing data about Berlin’s cultural
+    locations, events, and more. Expand the routes below to see the available
+    endpoints, send example requests, etc.
 
 
-    - **Events, Angebote, Orte und Akteure entdecken** - Hier entdecken Sie, was
-    kulturell in Berlin geboten wird. Viele Such- und Filtereinstellungen
-    ermöglichen es Ihnen, nur die Kulturorte und Kulturakteure zu finden, die
-    Sie wirklich benötigen.
-
-    - **Nutzer verwalten** - Für viele Funktionen dieser API müssen Sie als
-    Nutzer registriert sein. Hier können Sie sich registrieren und ihre
-    Nutzerdaten verwalten. 
-
-    - **Akteure verwalten** - Kulturaktuere betreiben Kulturorte und/oder bieten
-    Kulrutveranstaltungen an. Hier können Sie Akteure anlegen, diese verwalten
-    und anderen Nutzern Rechte geben, dies auch zu tun.
-
-    - **Orte verwalten** - Hier spielt die Musik. Kulturorte sind die Orte, an
-    denen Kulturveranstaltungen stattfinden. Hier können Sie als Akteur Orte
-    anlegen und diese verwalten. Auch können Sie anderen Nutzern Rechte geben,
-    dies auch zu tun. 
-
-    - **Angebote verwalten** - Bei einer Veranstaltung wird immer etwas
-    angeboten. Was dies ist, beschreibt das Angebot - ein Konzert, eine
-    Ausstellung oder eine Lesung. Hier können Sie als Akteur Angebote anlegen
-    und diese verwalten.
-
-    - **Events verwalten** - Eine Veranstaltung beantwortet die Frage: Was
-    (Angbot) findet wann (Termin), wo (Ort), von wem (Aktuer) und unter welchen
-    Umständen statt? Hier können Sie als Aktuer Veranstaltungen anlegen und
-    verwalten.
+    ⚠️ Please note that the API and its documentation are currently **work in
+    progress and subject to change**.
 
 
-
-    Um die API zu verwenden, benötigen Sie einen JWT (JSON Web Token), den Sie
-    durch einen login Request erhalten können. Senden Sie bei jedem API-Aufruf
-    den JWT im Header als Bearer-Token.
+    ## Entities
 
 
-    Hier ist ein Beispiel für einen API-Aufruf zum Abrufen von Informationen zu
-    einem Event:
+    - **Attraction**: A specific cultural happening, e.g. a concert, a play, or
+    a reading.
+
+    - **Location**: A geographical location, e.g. a theatre, a museum, or a
+    library.
+
+    - **Event**: An (or multiple) attraction(s) at a certain time at a certain
+    (or multiple) location(s).
+
+    - **Organization**: An organization that manages their content (attractions,
+    locations, and events).
+
+    - **User**: A user of the platform, e.g. admins or organization members.
+
+    - **Tag**: A descriptive tag that can be assigned to attractions, locations,
+    events, and organizations.
 
 
-    ```
+    ## Authentication
 
-    GET /api/events/{identifier}
 
-    Headers:
-      Authorization: Bearer {Ihr JWT}
+    If you want to use the API to *manage* (i.e. create or update) cultural
+    data, you need a user account with admin permissions. An initial admin user
+    can be created with the [seed
+    script](https://github.com/technologiestiftung/kulturdaten-api#initializing-an-empty-database).
 
+
+    Once you have the user account, you can send a login request:
+
+
+    ```shell
+
+    curl -X "POST" "http://localhost:3000/api/authentication/login" \  
+      -H \'Accept: application/json\' \  
+      -H \'Content-Type: application/json\' \  
+      -d $\'{ "email": "admin@example.com", "password": "plain-text-password" }\'
     ```
 
 
-    In der Antwort erhalten Sie detaillierte Informationen zum Event,
-    einschließlich Titel, Beschreibung, Datum und Veranstaltungsort.
+    The response of that login request contains a JWT (JSON Web Token) in the
+    `data.accessToken` field. Store it and send it along as an `Authorization`
+    header in the following requests, e.g.:
 
 
-    Sie können auch die API-Dokumentation für weitere Informationen und
-    Beispiele zu jedem Endpunkt konsultieren.
+    ```shell
+
+    curl -X "POST" "http://localhost:3000/api/admin/{some-admin-route}" \
+      -H \'Accept: application/json\' \
+      -H \'Content-Type: application/json\' \
+      -H \'Authorization: Bearer {accessToken}\' \
+      -d $\'{}\'
+    ```
+
+
+    ## Contact
+
+
+    Please get in touch if you have any questions or feedback:
+    [kontakt@kulturdaten.berlin](mailto:kontakt@kulturdaten.berlin)
+
+
+    The source code and more information can be found on GitHub:
+    <https://github.com/technologiestiftung/kulturdaten-api>
   version: 1.0.0
+  contact:
+    name: kulturdaten.berlin
+    url: https://www.kulturdaten.berlin/
+  license:
+    name: MIT
+    url: https://github.com/technologiestiftung/kulturdaten-api/LICENSE
 servers:
+  - url: /api/
+    description: This server
   - url: http://localhost:3000/api/
+    description: Local development server
+  - url: https://api-v2.kulturdaten.berlin/api/
+    description: Production server
+tags:
+  - name: Discover cultural data
+    description: Read data (attractions, events, etc.). No authentication required.
+  - name: Manage cultural data
+    description: Create and update data. All routes require authentication via JWT.
+  - name: Users
+    description: Manage users, reset your password, etc.
+  - name: Authentication
+    description: Log in with a user account.
+  - name: Admin
+    description: Manage data globally, or import third-party data.
+  - name: Server
+    description: Server-related routes, like health checks.
 paths:
   /attractions:
     get:
       tags:
         - Discover cultural data
       parameters:
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -103,7 +125,7 @@ paths:
                 $ref: "#/components/schemas/GetAttractionsResponse"
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -121,7 +143,7 @@ paths:
   /attractions/bulk-create:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -148,18 +170,8 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
       requestBody:
         content:
           application/json:
@@ -182,11 +194,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -196,7 +204,7 @@ paths:
                 $ref: "#/components/schemas/GetAttractionResponse"
     patch:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -216,7 +224,7 @@ paths:
   /attractions/{identifier}/externallinks:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -235,7 +243,7 @@ paths:
           description: OK
     delete:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -255,7 +263,7 @@ paths:
   /attractions/{identifier}/archive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -270,7 +278,7 @@ paths:
   /attractions/{identifier}/unarchive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -285,7 +293,7 @@ paths:
   /attractions/{identifier}/publish:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -300,7 +308,7 @@ paths:
   /attractions/{identifier}/unpublish:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -317,23 +325,9 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -343,7 +337,7 @@ paths:
                 $ref: "#/components/schemas/GetEventsResponse"
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -361,7 +355,7 @@ paths:
   /events/bulk-create:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -388,18 +382,8 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
       requestBody:
         content:
           application/json:
@@ -422,11 +406,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -436,7 +416,7 @@ paths:
                 $ref: "#/components/schemas/GetEventResponse"
     patch:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -456,7 +436,7 @@ paths:
   /events/{identifier}/locations:
     put:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -475,7 +455,7 @@ paths:
           description: OK
     delete:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -495,7 +475,7 @@ paths:
   /events/{identifier}/attractions:
     put:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -514,7 +494,7 @@ paths:
           description: OK
     delete:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -534,7 +514,7 @@ paths:
   /events/{identifier}/organizer:
     put:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -553,7 +533,7 @@ paths:
           description: OK
     delete:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -568,7 +548,7 @@ paths:
   /events/{identifier}/publish:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -583,7 +563,7 @@ paths:
   /events/{identifier}/unpublish:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -598,7 +578,7 @@ paths:
   /events/{identifier}/reschedule:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -618,7 +598,7 @@ paths:
   /events/{identifier}/postpone:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -633,7 +613,7 @@ paths:
   /events/{identifier}/cancel:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -648,7 +628,7 @@ paths:
   /events/{identifier}/archive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -663,7 +643,7 @@ paths:
   /events/{identifier}/unarchive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -678,7 +658,7 @@ paths:
   /events/{identifier}/duplicate:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -699,23 +679,9 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -725,7 +691,7 @@ paths:
                 $ref: "#/components/schemas/GetLocationsResponse"
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -743,7 +709,7 @@ paths:
   /locations/bulk-create:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -770,18 +736,8 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
       requestBody:
         content:
           application/json:
@@ -804,11 +760,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -818,9 +770,9 @@ paths:
                 $ref: "#/components/schemas/GetLocationResponse"
     patch:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -838,9 +790,9 @@ paths:
   /locations/{identifier}/manager:
     put:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -857,9 +809,9 @@ paths:
           description: OK
     delete:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -872,9 +824,9 @@ paths:
   /locations/{identifier}/open:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -887,9 +839,9 @@ paths:
   /locations/{identifier}/close:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -902,9 +854,9 @@ paths:
   /locations/{identifier}/permanentlyClose:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -917,9 +869,9 @@ paths:
   /locations/{identifier}/archive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -932,9 +884,9 @@ paths:
   /locations/{identifier}/unarchive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -947,9 +899,9 @@ paths:
   /locations/{identifier}/claim:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
-        - name: id
+        - name: identifier
           in: path
           required: true
           schema:
@@ -969,23 +921,9 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -995,7 +933,7 @@ paths:
                 $ref: "#/components/schemas/GetOrganizationsResponse"
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -1019,7 +957,7 @@ paths:
   /organizations/bulk-create:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       requestBody:
         content:
           application/json:
@@ -1046,18 +984,8 @@ paths:
       tags:
         - Discover cultural data
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
       requestBody:
         content:
           application/json:
@@ -1080,11 +1008,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: asReference
-          in: query
-          required: false
-          schema:
-            type: boolean
+        - $ref: "#/components/parameters/asReference"
       responses:
         "200":
           description: OK
@@ -1100,7 +1024,7 @@ paths:
                 $ref: "#/components/schemas/NotFoundError"
     patch:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1120,7 +1044,7 @@ paths:
   /organizations/{identifier}/activate:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1135,7 +1059,7 @@ paths:
   /organizations/{identifier}/deactivate:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1150,7 +1074,7 @@ paths:
   /organizations/{identifier}/retire:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1165,7 +1089,7 @@ paths:
   /organizations/{identifier}/archive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1180,7 +1104,7 @@ paths:
   /organizations/{identifier}/unarchive:
     post:
       tags:
-        - Maintain cultural data
+        - Manage cultural data
       parameters:
         - name: identifier
           in: path
@@ -1197,18 +1121,8 @@ paths:
       tags:
         - Users
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
       security:
         - bearerAuth: []
       responses:
@@ -1456,18 +1370,10 @@ paths:
       tags:
         - Admin
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Default value is 1
-          schema:
-            type: number
-        - name: pageSize
-          in: query
-          required: false
-          description: Default value is 30
-          schema:
-            type: number
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -1486,6 +1392,8 @@ paths:
           required: true
           schema:
             type: string
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -1561,6 +1469,31 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    asReference:
+      name: asReference
+      description: Return references instead of full objects
+      in: query
+      required: false
+      example: false
+      schema:
+        type: boolean
+    page:
+      name: page
+      description: Default value is 1
+      in: query
+      required: false
+      example: 1
+      schema:
+        type: number
+    pageSize:
+      name: pageSize
+      description: Default value is 30
+      in: query
+      required: false
+      example: 30
+      schema:
+        type: number
   schemas:
     Reference:
       type: object
@@ -1573,6 +1506,12 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
     Response:
       type: object
       properties:
@@ -1624,17 +1563,33 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
+              description: The date and time the object was created (ISO timestamp).
+              example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
+              example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
+              description: The source of this object.
+              example: bezirkskalender
             originObjectID:
               type: string
+              description: The original ID of this object in the original system.
             availableLanguages:
               type: array
+              description: List of languages this object is available in.
+              example:
+                - de
+                - en
               items:
                 type: string
         status:
@@ -1655,36 +1610,85 @@ components:
           properties:
             startDate:
               type: string
+              description: >-
+                The date (year, month, day) the event starts, in timezone
+                Europe/Berlin.
+              example: "2023-09-08"
             startTime:
               type: string
+              description: The time the event starts, in timezone Europe/Berlin.
+              example: "20:00:00"
             permanentOpening:
               type: boolean
+              description: >-
+                Indicates whether the event is permanently open (and has no end
+                date/time).
+              example: false
             doorTime:
               type: string
+              description: >-
+                The time that guests can enter the venue, in timezone
+                Europe/Berlin.
+              example: "19:00:00"
             endDate:
               type: string
+              description: >-
+                The date (year, month, day) the event ends, in timezone
+                Europe/Berlin.
+              example: "2023-09-08"
             endTime:
               type: string
+              description: The time the event end, in timezone Europe/Berlin.
+              example: "22:00"
         title:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
+          example: https://example.com/
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -1704,6 +1708,12 @@ components:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
         attractions:
           type: array
           items:
@@ -1717,6 +1727,12 @@ components:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
         organizer:
           type: object
           properties:
@@ -1728,22 +1744,44 @@ components:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
         admission:
           type: object
+          description: Information about the admission to the event/attraction.
           properties:
             note:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
             ticketType:
               type: string
               enum:
@@ -1757,6 +1795,7 @@ components:
                 - registrationType.registrationDesired
             admissionLink:
               type: string
+              example: https://example.com/
     AdminAttraction:
       type: object
       required:
@@ -1774,17 +1813,33 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
+              description: The date and time the object was created (ISO timestamp).
+              example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
+              example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
+              description: The source of this object.
+              example: bezirkskalender
             originObjectID:
               type: string
+              description: The original ID of this object in the original system.
             availableLanguages:
               type: array
+              description: List of languages this object is available in.
+              example:
+                - de
+                - en
               items:
                 type: string
         status:
@@ -1797,22 +1852,50 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -1834,17 +1917,34 @@ components:
                 type: string
               metadata:
                 type: object
+                required:
+                  - created
+                  - updated
                 properties:
                   created:
                     type: string
+                    description: The date and time the object was created (ISO timestamp).
+                    example: "2011-10-05T14:48:00.000Z"
                   updated:
                     type: string
+                    description: >-
+                      The date and time the object was last updated (ISO
+                      timestamp). Is identical to created date after first
+                      creation.
+                    example: "2011-10-05T14:48:00.000Z"
                   origin:
                     type: string
+                    description: The source of this object.
+                    example: bezirkskalender
                   originObjectID:
                     type: string
+                    description: The original ID of this object in the original system.
                   availableLanguages:
                     type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
                     items:
                       type: string
               status:
@@ -1865,36 +1965,85 @@ components:
                 properties:
                   startDate:
                     type: string
+                    description: >-
+                      The date (year, month, day) the event starts, in timezone
+                      Europe/Berlin.
+                    example: "2023-09-08"
                   startTime:
                     type: string
+                    description: The time the event starts, in timezone Europe/Berlin.
+                    example: "20:00:00"
                   permanentOpening:
                     type: boolean
+                    description: >-
+                      Indicates whether the event is permanently open (and has
+                      no end date/time).
+                    example: false
                   doorTime:
                     type: string
+                    description: >-
+                      The time that guests can enter the venue, in timezone
+                      Europe/Berlin.
+                    example: "19:00:00"
                   endDate:
                     type: string
+                    description: >-
+                      The date (year, month, day) the event ends, in timezone
+                      Europe/Berlin.
+                    example: "2023-09-08"
                   endTime:
                     type: string
+                    description: The time the event end, in timezone Europe/Berlin.
+                    example: "22:00"
               title:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
               displayName:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
               description:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
               pleaseNote:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
               website:
                 type: string
+                example: https://example.com/
               inLanguages:
                 type: array
+                description: List of languages this object is available in.
+                example:
+                  - de
+                  - en
                 items:
                   type: string
               tags:
@@ -1914,6 +2063,12 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                      description: >-
+                        A string that can be translated into multiple languages,
+                        e.g. { "de": "Konzert", "en": "concert" }
+                      example:
+                        de: Konzert
+                        en: concert
               attractions:
                 type: array
                 items:
@@ -1927,6 +2082,12 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                      description: >-
+                        A string that can be translated into multiple languages,
+                        e.g. { "de": "Konzert", "en": "concert" }
+                      example:
+                        de: Konzert
+                        en: concert
               organizer:
                 type: object
                 properties:
@@ -1938,22 +2099,44 @@ components:
                     type: object
                     additionalProperties:
                       type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
               contact:
                 type: object
+                description: >-
+                  A person that is connected to and/or responsible for the
+                  referenced entity.
                 properties:
                   name:
                     type: string
+                    description: Full name of the contact person.
+                    example: Jane Doe
                   email:
                     type: string
+                    description: Email address of the contact person.
+                    example: someone@example.com
                   telephone:
                     type: string
+                    description: Phone number of the contact person.
+                    example: +49 30 12345678
               admission:
                 type: object
+                description: Information about the admission to the event/attraction.
                 properties:
                   note:
                     type: object
                     additionalProperties:
                       type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
                   ticketType:
                     type: string
                     enum:
@@ -1967,15 +2150,19 @@ components:
                       - registrationType.registrationDesired
                   admissionLink:
                     type: string
+                    example: https://example.com/
         externalLinks:
           type: array
+          description: Links to external resources related to this object.
           items:
             type: object
             properties:
               displayName:
                 type: string
+                example: Website
               url:
                 type: string
+                example: https://example.com/
             required:
               - url
     Attraction:
@@ -1994,17 +2181,33 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
+              description: The date and time the object was created (ISO timestamp).
+              example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
+              example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
+              description: The source of this object.
+              example: bezirkskalender
             originObjectID:
               type: string
+              description: The original ID of this object in the original system.
             availableLanguages:
               type: array
+              description: List of languages this object is available in.
+              example:
+                - de
+                - en
               items:
                 type: string
         status:
@@ -2017,37 +2220,66 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: The main title of the attraction.
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Eine Beschreibung
+            en: Some description
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: Any important information for the attendees of the attraction.
+          example:
+            de: Achtung, laute Geräusche
+            en: Warning, loud noises
         website:
           type: string
+          example: https://example.com/
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
           type: array
+          description: List of tags for this attraction.
           items:
             type: string
         externalLinks:
           type: array
+          description: Links to external resources related to this object.
           items:
             type: object
             properties:
               displayName:
                 type: string
+                example: Website
               url:
                 type: string
+                example: https://example.com/
             required:
               - url
     Location:
@@ -2063,17 +2295,33 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
+              description: The date and time the object was created (ISO timestamp).
+              example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
+              example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
+              description: The source of this object.
+              example: bezirkskalender
             originObjectID:
               type: string
+              description: The original ID of this object in the original system.
             availableLanguages:
               type: array
+              description: List of languages this object is available in.
+              example:
+                - de
+                - en
               items:
                 type: string
         status:
@@ -2086,29 +2334,56 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
+          example: https://example.com/
         address:
           type: object
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -2128,8 +2403,10 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
@@ -2150,6 +2427,7 @@ components:
                 description: >-
                   The closing hour of the place or service on the given day(s)
                   of the week.
+                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -2166,6 +2444,7 @@ components:
                 description: >-
                   The opening hour of the place or service on the given day(s)
                   of the week.
+                example: "12:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -2176,6 +2455,10 @@ components:
                   of an offer, salary period, or a period of opening hours.
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -2190,13 +2473,16 @@ components:
           type: array
           items:
             type: array
+            description: Links to external resources related to this object.
             items:
               type: object
               properties:
                 displayName:
                   type: string
+                  example: Website
                 url:
                   type: string
+                  example: https://example.com/
               required:
                 - url
         manager:
@@ -2210,15 +2496,29 @@ components:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
+          description: The managing person of this location.
         contact:
           type: object
+          description: The main contact person of this location.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
     Organization:
       type: object
       required:
@@ -2232,17 +2532,33 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
+              description: The date and time the object was created (ISO timestamp).
+              example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
+              example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
+              description: The source of this object.
+              example: bezirkskalender
             originObjectID:
               type: string
+              description: The original ID of this object in the original system.
             availableLanguages:
               type: array
+              description: List of languages this object is available in.
+              example:
+                - de
+                - en
               items:
                 type: string
         status:
@@ -2261,18 +2577,41 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
+          example: https://example.com/
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -2284,14 +2623,22 @@ components:
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -2311,21 +2658,32 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
     User:
       type: object
       properties:
@@ -2406,17 +2764,36 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
+                      description: >-
+                        The date and time the object was created (ISO
+                        timestamp).
+                      example: "2011-10-05T14:48:00.000Z"
                     updated:
                       type: string
+                      description: >-
+                        The date and time the object was last updated (ISO
+                        timestamp). Is identical to created date after first
+                        creation.
+                      example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
+                      description: The source of this object.
+                      example: bezirkskalender
                     originObjectID:
                       type: string
+                      description: The original ID of this object in the original system.
                     availableLanguages:
                       type: array
+                      description: List of languages this object is available in.
+                      example:
+                        - de
+                        - en
                       items:
                         type: string
                 status:
@@ -2435,18 +2812,41 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 displayName:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 description:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 website:
                   type: string
+                  example: https://example.com/
                 inLanguages:
                   type: array
+                  description: List of languages this object is available in.
+                  example:
+                    - de
+                    - en
                   items:
                     type: string
                 tags:
@@ -2458,14 +2858,22 @@ components:
                   properties:
                     streetAddress:
                       type: string
+                      description: Street address (street name and house number)
+                      example: Beispielstraße 1
                     addressLocality:
                       type: string
+                      example: Berlin
                     postalCode:
                       type: string
+                      example: 12345
                     description:
                       type: string
+                      example: Main hall
                 borough:
                   type: string
+                  description: >-
+                    The Berlin district (or "außerhalb", if the event happens
+                    outside of Berlin).
                   enum:
                     - Mitte
                     - Friedrichshain-Kreuzberg
@@ -2485,21 +2893,32 @@ components:
                   properties:
                     latitude:
                       type: string
+                      example: "52.521008"
                     longitude:
                       type: string
+                      example: "13.405954"
                     coordinateSystem:
                       type: string
                       enum:
                         - WGS84 (Decimal Degrees)
                 contact:
                   type: object
+                  description: >-
+                    A person that is connected to and/or responsible for the
+                    referenced entity.
                   properties:
                     name:
                       type: string
+                      description: Full name of the contact person.
+                      example: Jane Doe
                     email:
                       type: string
+                      description: Email address of the contact person.
+                      example: someone@example.com
                     telephone:
                       type: string
+                      description: Phone number of the contact person.
+                      example: +49 30 12345678
             organizationReference:
               type: object
               properties:
@@ -2511,6 +2930,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     GetOrganizationsResponse:
@@ -2521,136 +2946,219 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            organizations:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Organization
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                organizations:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Organization
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - organization.published
+                          - organization.unpublished
+                          - organization.archived
+                      activationStatus:
                         type: string
-                      availableLanguages:
+                        enum:
+                          - organization.active
+                          - organization.inactive
+                          - organization.retired
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
+                        type: string
+                        example: https://example.com/
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - organization.published
-                      - organization.unpublished
-                      - organization.archived
-                  activationStatus:
-                    type: string
-                    enum:
-                      - organization.active
-                      - organization.inactive
-                      - organization.retired
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  address:
-                    type: object
-                    properties:
-                      streetAddress:
+                      address:
+                        type: object
+                        properties:
+                          streetAddress:
+                            type: string
+                            description: Street address (street name and house number)
+                            example: Beispielstraße 1
+                          addressLocality:
+                            type: string
+                            example: Berlin
+                          postalCode:
+                            type: string
+                            example: 12345
+                          description:
+                            type: string
+                            example: Main hall
+                      borough:
                         type: string
-                      addressLocality:
-                        type: string
-                      postalCode:
-                        type: string
-                      description:
-                        type: string
-                  borough:
-                    type: string
-                    enum:
-                      - Mitte
-                      - Friedrichshain-Kreuzberg
-                      - Pankow
-                      - Charlottenburg-Wilmersdorf
-                      - Spandau
-                      - Steglitz-Zehlendorf
-                      - Tempelhof-Schöneberg
-                      - Neukölln
-                      - Treptow-Köpenick
-                      - Marzahn-Hellersdorf
-                      - Lichtenberg
-                      - Reinickendorf
-                      - außerhalb
-                  coordinates:
-                    type: object
-                    properties:
-                      latitude:
-                        type: string
-                      longitude:
-                        type: string
-                      coordinateSystem:
-                        type: string
+                        description: >-
+                          The Berlin district (or "außerhalb", if the event
+                          happens outside of Berlin).
                         enum:
-                          - WGS84 (Decimal Degrees)
-                  contact:
+                          - Mitte
+                          - Friedrichshain-Kreuzberg
+                          - Pankow
+                          - Charlottenburg-Wilmersdorf
+                          - Spandau
+                          - Steglitz-Zehlendorf
+                          - Tempelhof-Schöneberg
+                          - Neukölln
+                          - Treptow-Köpenick
+                          - Marzahn-Hellersdorf
+                          - Lichtenberg
+                          - Reinickendorf
+                          - außerhalb
+                      coordinates:
+                        type: object
+                        properties:
+                          latitude:
+                            type: string
+                            example: "52.521008"
+                          longitude:
+                            type: string
+                            example: "13.405954"
+                          coordinateSystem:
+                            type: string
+                            enum:
+                              - WGS84 (Decimal Degrees)
+                      contact:
+                        type: object
+                        description: >-
+                          A person that is connected to and/or responsible for
+                          the referenced entity.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                organizationsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
-                      name:
+                      referenceType:
                         type: string
-                      email:
+                      referenceId:
                         type: string
-                      telephone:
-                        type: string
-            organizationsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     CreateOrganizationRequest:
@@ -2664,18 +3172,40 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -2687,14 +3217,22 @@ components:
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -2714,21 +3252,32 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
         metadata:
           type: object
           properties:
@@ -2761,6 +3310,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     SearchOrganizationsRequest:
@@ -2777,136 +3332,219 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            organizations:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Organization
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                organizations:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Organization
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - organization.published
+                          - organization.unpublished
+                          - organization.archived
+                      activationStatus:
                         type: string
-                      availableLanguages:
+                        enum:
+                          - organization.active
+                          - organization.inactive
+                          - organization.retired
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
+                        type: string
+                        example: https://example.com/
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - organization.published
-                      - organization.unpublished
-                      - organization.archived
-                  activationStatus:
-                    type: string
-                    enum:
-                      - organization.active
-                      - organization.inactive
-                      - organization.retired
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  address:
-                    type: object
-                    properties:
-                      streetAddress:
+                      address:
+                        type: object
+                        properties:
+                          streetAddress:
+                            type: string
+                            description: Street address (street name and house number)
+                            example: Beispielstraße 1
+                          addressLocality:
+                            type: string
+                            example: Berlin
+                          postalCode:
+                            type: string
+                            example: 12345
+                          description:
+                            type: string
+                            example: Main hall
+                      borough:
                         type: string
-                      addressLocality:
-                        type: string
-                      postalCode:
-                        type: string
-                      description:
-                        type: string
-                  borough:
-                    type: string
-                    enum:
-                      - Mitte
-                      - Friedrichshain-Kreuzberg
-                      - Pankow
-                      - Charlottenburg-Wilmersdorf
-                      - Spandau
-                      - Steglitz-Zehlendorf
-                      - Tempelhof-Schöneberg
-                      - Neukölln
-                      - Treptow-Köpenick
-                      - Marzahn-Hellersdorf
-                      - Lichtenberg
-                      - Reinickendorf
-                      - außerhalb
-                  coordinates:
-                    type: object
-                    properties:
-                      latitude:
-                        type: string
-                      longitude:
-                        type: string
-                      coordinateSystem:
-                        type: string
+                        description: >-
+                          The Berlin district (or "außerhalb", if the event
+                          happens outside of Berlin).
                         enum:
-                          - WGS84 (Decimal Degrees)
-                  contact:
+                          - Mitte
+                          - Friedrichshain-Kreuzberg
+                          - Pankow
+                          - Charlottenburg-Wilmersdorf
+                          - Spandau
+                          - Steglitz-Zehlendorf
+                          - Tempelhof-Schöneberg
+                          - Neukölln
+                          - Treptow-Köpenick
+                          - Marzahn-Hellersdorf
+                          - Lichtenberg
+                          - Reinickendorf
+                          - außerhalb
+                      coordinates:
+                        type: object
+                        properties:
+                          latitude:
+                            type: string
+                            example: "52.521008"
+                          longitude:
+                            type: string
+                            example: "13.405954"
+                          coordinateSystem:
+                            type: string
+                            enum:
+                              - WGS84 (Decimal Degrees)
+                      contact:
+                        type: object
+                        description: >-
+                          A person that is connected to and/or responsible for
+                          the referenced entity.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                organizationsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
-                      name:
+                      referenceType:
                         type: string
-                      email:
+                      referenceId:
                         type: string
-                      telephone:
-                        type: string
-            organizationsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     UpdateOrganizationRequest:
@@ -2916,18 +3554,40 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -2939,14 +3599,22 @@ components:
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -2966,21 +3634,32 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
     GetAttractionsResponse:
       type: object
       properties:
@@ -2989,101 +3668,173 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            attractions:
-              type: array
-              items:
-                type: object
-                required:
-                  - type
-                  - identifier
-                  - metadata
-                  - title
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Attraction
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                attractions:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Attraction
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - attraction.published
+                          - attraction.unpublished
+                          - attraction.archived
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: The main title of the attraction.
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Eine Beschreibung
+                          en: Some description
+                      pleaseNote:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          Any important information for the attendees of the
+                          attraction.
+                        example:
+                          de: Achtung, laute Geräusche
+                          en: Warning, loud noises
+                      website:
                         type: string
-                      availableLanguages:
+                        example: https://example.com/
+                      inLanguages:
                         type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - attraction.published
-                      - attraction.unpublished
-                      - attraction.archived
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  pleaseNote:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  externalLinks:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        displayName:
+                      tags:
+                        type: array
+                        description: List of tags for this attraction.
+                        items:
                           type: string
-                        url:
-                          type: string
-                      required:
-                        - url
-            attractionsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
+                      externalLinks:
+                        type: array
+                        description: Links to external resources related to this object.
+                        items:
+                          type: object
+                          properties:
+                            displayName:
+                              type: string
+                              example: Website
+                            url:
+                              type: string
+                              example: https://example.com/
+                          required:
+                            - url
+                attractionsReferences:
+                  type: array
+                  items:
                     type: object
-                    additionalProperties:
-                      type: string
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     CreateAttractionRequest:
@@ -3097,22 +3848,50 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -3121,13 +3900,16 @@ components:
             type: string
         externalLinks:
           type: array
+          description: Links to external resources related to this object.
           items:
             type: object
             properties:
               displayName:
                 type: string
+                example: Website
               url:
                 type: string
+                example: https://example.com/
             required:
               - url
         metadata:
@@ -3163,6 +3945,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     SearchAttractionsRequest:
@@ -3179,101 +3967,173 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            attractions:
-              type: array
-              items:
-                type: object
-                required:
-                  - type
-                  - identifier
-                  - metadata
-                  - title
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Attraction
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                attractions:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Attraction
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - attraction.published
+                          - attraction.unpublished
+                          - attraction.archived
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: The main title of the attraction.
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Eine Beschreibung
+                          en: Some description
+                      pleaseNote:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          Any important information for the attendees of the
+                          attraction.
+                        example:
+                          de: Achtung, laute Geräusche
+                          en: Warning, loud noises
+                      website:
                         type: string
-                      availableLanguages:
+                        example: https://example.com/
+                      inLanguages:
                         type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - attraction.published
-                      - attraction.unpublished
-                      - attraction.archived
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  pleaseNote:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  externalLinks:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        displayName:
+                      tags:
+                        type: array
+                        description: List of tags for this attraction.
+                        items:
                           type: string
-                        url:
-                          type: string
-                      required:
-                        - url
-            attractionsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
+                      externalLinks:
+                        type: array
+                        description: Links to external resources related to this object.
+                        items:
+                          type: object
+                          properties:
+                            displayName:
+                              type: string
+                              example: Website
+                            url:
+                              type: string
+                              example: https://example.com/
+                          required:
+                            - url
+                attractionsReferences:
+                  type: array
+                  items:
                     type: object
-                    additionalProperties:
-                      type: string
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     GetAttractionResponse:
@@ -3302,17 +4162,36 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
+                      description: >-
+                        The date and time the object was created (ISO
+                        timestamp).
+                      example: "2011-10-05T14:48:00.000Z"
                     updated:
                       type: string
+                      description: >-
+                        The date and time the object was last updated (ISO
+                        timestamp). Is identical to created date after first
+                        creation.
+                      example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
+                      description: The source of this object.
+                      example: bezirkskalender
                     originObjectID:
                       type: string
+                      description: The original ID of this object in the original system.
                     availableLanguages:
                       type: array
+                      description: List of languages this object is available in.
+                      example:
+                        - de
+                        - en
                       items:
                         type: string
                 status:
@@ -3325,37 +4204,68 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: The main title of the attraction.
+                  example:
+                    de: Konzert
+                    en: concert
                 displayName:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 description:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Eine Beschreibung
+                    en: Some description
                 pleaseNote:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    Any important information for the attendees of the
+                    attraction.
+                  example:
+                    de: Achtung, laute Geräusche
+                    en: Warning, loud noises
                 website:
                   type: string
+                  example: https://example.com/
                 inLanguages:
                   type: array
+                  description: List of languages this object is available in.
+                  example:
+                    - de
+                    - en
                   items:
                     type: string
                 tags:
                   type: array
+                  description: List of tags for this attraction.
                   items:
                     type: string
                 externalLinks:
                   type: array
+                  description: Links to external resources related to this object.
                   items:
                     type: object
                     properties:
                       displayName:
                         type: string
+                        example: Website
                       url:
                         type: string
+                        example: https://example.com/
                     required:
                       - url
             attractionReference:
@@ -3369,6 +4279,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     UpdateAttractionRequest:
@@ -3378,22 +4294,50 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -3402,13 +4346,16 @@ components:
             type: string
         externalLinks:
           type: array
+          description: Links to external resources related to this object.
           items:
             type: object
             properties:
               displayName:
                 type: string
+                example: Website
               url:
                 type: string
+                example: https://example.com/
             required:
               - url
     GetLocationsResponse:
@@ -3419,169 +4366,279 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            locations:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Location
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                locations:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Location
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - location.published
+                          - location.unpublished
+                          - location.archived
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
                         type: string
-                      availableLanguages:
+                        example: https://example.com/
+                      address:
+                        type: object
+                        properties:
+                          streetAddress:
+                            type: string
+                            description: Street address (street name and house number)
+                            example: Beispielstraße 1
+                          addressLocality:
+                            type: string
+                            example: Berlin
+                          postalCode:
+                            type: string
+                            example: 12345
+                          description:
+                            type: string
+                            example: Main hall
+                      borough:
+                        type: string
+                        description: >-
+                          The Berlin district (or "außerhalb", if the event
+                          happens outside of Berlin).
+                        enum:
+                          - Mitte
+                          - Friedrichshain-Kreuzberg
+                          - Pankow
+                          - Charlottenburg-Wilmersdorf
+                          - Spandau
+                          - Steglitz-Zehlendorf
+                          - Tempelhof-Schöneberg
+                          - Neukölln
+                          - Treptow-Köpenick
+                          - Marzahn-Hellersdorf
+                          - Lichtenberg
+                          - Reinickendorf
+                          - außerhalb
+                      coordinates:
+                        type: object
+                        properties:
+                          latitude:
+                            type: string
+                            example: "52.521008"
+                          longitude:
+                            type: string
+                            example: "13.405954"
+                          coordinateSystem:
+                            type: string
+                            enum:
+                              - WGS84 (Decimal Degrees)
+                      openingStatus:
+                        type: string
+                        enum:
+                          - location.opened
+                          - location.closed
+                          - location.permanentlyClosed
+                      openingHours:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day(s) of the week.
+                              example: "22:00"
+                            dayOfWeek:
+                              type: string
+                              enum:
+                                - Monday
+                                - Tuesday
+                                - Wednesday
+                                - Thursday
+                                - Friday
+                                - Saturday
+                                - Sunday
+                              description: >-
+                                The day of the week for which these opening
+                                hours are valid.
+                            opens:
+                              type: string
+                              description: >-
+                                The opening hour of the place or service on the
+                                given day(s) of the week.
+                              example: "12:00"
+                            validFrom:
+                              type: string
+                              description: The date when the item becomes valid.
+                            validThrough:
+                              type: string
+                              description: >-
+                                The date after when the item is not valid. For
+                                example the end of an offer, salary period, or a
+                                period of opening hours.
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - location.published
-                      - location.unpublished
-                      - location.archived
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  address:
-                    type: object
-                    properties:
-                      streetAddress:
-                        type: string
-                      addressLocality:
-                        type: string
-                      postalCode:
-                        type: string
-                      description:
-                        type: string
-                  borough:
-                    type: string
-                    enum:
-                      - Mitte
-                      - Friedrichshain-Kreuzberg
-                      - Pankow
-                      - Charlottenburg-Wilmersdorf
-                      - Spandau
-                      - Steglitz-Zehlendorf
-                      - Tempelhof-Schöneberg
-                      - Neukölln
-                      - Treptow-Köpenick
-                      - Marzahn-Hellersdorf
-                      - Lichtenberg
-                      - Reinickendorf
-                      - außerhalb
-                  coordinates:
-                    type: object
-                    properties:
-                      latitude:
-                        type: string
-                      longitude:
-                        type: string
-                      coordinateSystem:
-                        type: string
-                        enum:
-                          - WGS84 (Decimal Degrees)
-                  openingStatus:
-                    type: string
-                    enum:
-                      - location.opened
-                      - location.closed
-                      - location.permanentlyClosed
-                  openingHours:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        closes:
+                      accessibility:
+                        type: array
+                        items:
                           type: string
-                          description: >-
-                            The closing hour of the place or service on the
-                            given day(s) of the week.
-                        dayOfWeek:
-                          type: string
-                          enum:
-                            - Monday
-                            - Tuesday
-                            - Wednesday
-                            - Thursday
-                            - Friday
-                            - Saturday
-                            - Sunday
-                          description: >-
-                            The day of the week for which these opening hours
-                            are valid.
-                        opens:
-                          type: string
-                          description: >-
-                            The opening hour of the place or service on the
-                            given day(s) of the week.
-                        validFrom:
-                          type: string
-                          description: The date when the item becomes valid.
-                        validThrough:
-                          type: string
-                          description: >-
-                            The date after when the item is not valid. For
-                            example the end of an offer, salary period, or a
-                            period of opening hours.
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  accessibility:
-                    type: array
-                    items:
-                      type: string
-                  externalLinks:
-                    type: array
-                    items:
-                      type: array
-                      items:
+                      externalLinks:
+                        type: array
+                        items:
+                          type: array
+                          description: Links to external resources related to this object.
+                          items:
+                            type: object
+                            properties:
+                              displayName:
+                                type: string
+                                example: Website
+                              url:
+                                type: string
+                                example: https://example.com/
+                            required:
+                              - url
+                      manager:
                         type: object
                         properties:
-                          displayName:
+                          referenceType:
                             type: string
-                          url:
+                          referenceId:
                             type: string
-                        required:
-                          - url
-                  manager:
+                          referenceLabel:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                        description: The managing person of this location.
+                      contact:
+                        type: object
+                        description: The main contact person of this location.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                locationsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
                       referenceType:
@@ -3592,28 +4649,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
-                  contact:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      email:
-                        type: string
-                      telephone:
-                        type: string
-            locationsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     CreateLocationRequest:
@@ -3627,14 +4668,32 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         address:
@@ -3642,14 +4701,22 @@ components:
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -3669,8 +4736,10 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
@@ -3685,6 +4754,7 @@ components:
                 description: >-
                   The closing hour of the place or service on the given day(s)
                   of the week.
+                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -3701,6 +4771,7 @@ components:
                 description: >-
                   The opening hour of the place or service on the given day(s)
                   of the week.
+                example: "12:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -3711,6 +4782,10 @@ components:
                   of an offer, salary period, or a period of opening hours.
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -3721,13 +4796,16 @@ components:
           type: array
           items:
             type: array
+            description: Links to external resources related to this object.
             items:
               type: object
               properties:
                 displayName:
                   type: string
+                  example: Website
                 url:
                   type: string
+                  example: https://example.com/
               required:
                 - url
         manager:
@@ -3741,15 +4819,30 @@ components:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
         metadata:
           type: object
           properties:
@@ -3783,6 +4876,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     SearchLocationsRequest:
@@ -3799,169 +4898,279 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            locations:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Location
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                locations:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Location
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - location.published
+                          - location.unpublished
+                          - location.archived
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
                         type: string
-                      availableLanguages:
+                        example: https://example.com/
+                      address:
+                        type: object
+                        properties:
+                          streetAddress:
+                            type: string
+                            description: Street address (street name and house number)
+                            example: Beispielstraße 1
+                          addressLocality:
+                            type: string
+                            example: Berlin
+                          postalCode:
+                            type: string
+                            example: 12345
+                          description:
+                            type: string
+                            example: Main hall
+                      borough:
+                        type: string
+                        description: >-
+                          The Berlin district (or "außerhalb", if the event
+                          happens outside of Berlin).
+                        enum:
+                          - Mitte
+                          - Friedrichshain-Kreuzberg
+                          - Pankow
+                          - Charlottenburg-Wilmersdorf
+                          - Spandau
+                          - Steglitz-Zehlendorf
+                          - Tempelhof-Schöneberg
+                          - Neukölln
+                          - Treptow-Köpenick
+                          - Marzahn-Hellersdorf
+                          - Lichtenberg
+                          - Reinickendorf
+                          - außerhalb
+                      coordinates:
+                        type: object
+                        properties:
+                          latitude:
+                            type: string
+                            example: "52.521008"
+                          longitude:
+                            type: string
+                            example: "13.405954"
+                          coordinateSystem:
+                            type: string
+                            enum:
+                              - WGS84 (Decimal Degrees)
+                      openingStatus:
+                        type: string
+                        enum:
+                          - location.opened
+                          - location.closed
+                          - location.permanentlyClosed
+                      openingHours:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day(s) of the week.
+                              example: "22:00"
+                            dayOfWeek:
+                              type: string
+                              enum:
+                                - Monday
+                                - Tuesday
+                                - Wednesday
+                                - Thursday
+                                - Friday
+                                - Saturday
+                                - Sunday
+                              description: >-
+                                The day of the week for which these opening
+                                hours are valid.
+                            opens:
+                              type: string
+                              description: >-
+                                The opening hour of the place or service on the
+                                given day(s) of the week.
+                              example: "12:00"
+                            validFrom:
+                              type: string
+                              description: The date when the item becomes valid.
+                            validThrough:
+                              type: string
+                              description: >-
+                                The date after when the item is not valid. For
+                                example the end of an offer, salary period, or a
+                                period of opening hours.
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - location.published
-                      - location.unpublished
-                      - location.archived
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  address:
-                    type: object
-                    properties:
-                      streetAddress:
-                        type: string
-                      addressLocality:
-                        type: string
-                      postalCode:
-                        type: string
-                      description:
-                        type: string
-                  borough:
-                    type: string
-                    enum:
-                      - Mitte
-                      - Friedrichshain-Kreuzberg
-                      - Pankow
-                      - Charlottenburg-Wilmersdorf
-                      - Spandau
-                      - Steglitz-Zehlendorf
-                      - Tempelhof-Schöneberg
-                      - Neukölln
-                      - Treptow-Köpenick
-                      - Marzahn-Hellersdorf
-                      - Lichtenberg
-                      - Reinickendorf
-                      - außerhalb
-                  coordinates:
-                    type: object
-                    properties:
-                      latitude:
-                        type: string
-                      longitude:
-                        type: string
-                      coordinateSystem:
-                        type: string
-                        enum:
-                          - WGS84 (Decimal Degrees)
-                  openingStatus:
-                    type: string
-                    enum:
-                      - location.opened
-                      - location.closed
-                      - location.permanentlyClosed
-                  openingHours:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        closes:
+                      accessibility:
+                        type: array
+                        items:
                           type: string
-                          description: >-
-                            The closing hour of the place or service on the
-                            given day(s) of the week.
-                        dayOfWeek:
-                          type: string
-                          enum:
-                            - Monday
-                            - Tuesday
-                            - Wednesday
-                            - Thursday
-                            - Friday
-                            - Saturday
-                            - Sunday
-                          description: >-
-                            The day of the week for which these opening hours
-                            are valid.
-                        opens:
-                          type: string
-                          description: >-
-                            The opening hour of the place or service on the
-                            given day(s) of the week.
-                        validFrom:
-                          type: string
-                          description: The date when the item becomes valid.
-                        validThrough:
-                          type: string
-                          description: >-
-                            The date after when the item is not valid. For
-                            example the end of an offer, salary period, or a
-                            period of opening hours.
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  accessibility:
-                    type: array
-                    items:
-                      type: string
-                  externalLinks:
-                    type: array
-                    items:
-                      type: array
-                      items:
+                      externalLinks:
+                        type: array
+                        items:
+                          type: array
+                          description: Links to external resources related to this object.
+                          items:
+                            type: object
+                            properties:
+                              displayName:
+                                type: string
+                                example: Website
+                              url:
+                                type: string
+                                example: https://example.com/
+                            required:
+                              - url
+                      manager:
                         type: object
                         properties:
-                          displayName:
+                          referenceType:
                             type: string
-                          url:
+                          referenceId:
                             type: string
-                        required:
-                          - url
-                  manager:
+                          referenceLabel:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                        description: The managing person of this location.
+                      contact:
+                        type: object
+                        description: The main contact person of this location.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                locationsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
                       referenceType:
@@ -3972,28 +5181,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
-                  contact:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      email:
-                        type: string
-                      telephone:
-                        type: string
-            locationsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     GetLocationResponse:
@@ -4019,17 +5212,36 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
+                      description: >-
+                        The date and time the object was created (ISO
+                        timestamp).
+                      example: "2011-10-05T14:48:00.000Z"
                     updated:
                       type: string
+                      description: >-
+                        The date and time the object was last updated (ISO
+                        timestamp). Is identical to created date after first
+                        creation.
+                      example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
+                      description: The source of this object.
+                      example: bezirkskalender
                     originObjectID:
                       type: string
+                      description: The original ID of this object in the original system.
                     availableLanguages:
                       type: array
+                      description: List of languages this object is available in.
+                      example:
+                        - de
+                        - en
                       items:
                         type: string
                 status:
@@ -4042,29 +5254,56 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 displayName:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 description:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 website:
                   type: string
+                  example: https://example.com/
                 address:
                   type: object
                   properties:
                     streetAddress:
                       type: string
+                      description: Street address (street name and house number)
+                      example: Beispielstraße 1
                     addressLocality:
                       type: string
+                      example: Berlin
                     postalCode:
                       type: string
+                      example: 12345
                     description:
                       type: string
+                      example: Main hall
                 borough:
                   type: string
+                  description: >-
+                    The Berlin district (or "außerhalb", if the event happens
+                    outside of Berlin).
                   enum:
                     - Mitte
                     - Friedrichshain-Kreuzberg
@@ -4084,8 +5323,10 @@ components:
                   properties:
                     latitude:
                       type: string
+                      example: "52.521008"
                     longitude:
                       type: string
+                      example: "13.405954"
                     coordinateSystem:
                       type: string
                       enum:
@@ -4106,6 +5347,7 @@ components:
                         description: >-
                           The closing hour of the place or service on the given
                           day(s) of the week.
+                        example: "22:00"
                       dayOfWeek:
                         type: string
                         enum:
@@ -4124,6 +5366,7 @@ components:
                         description: >-
                           The opening hour of the place or service on the given
                           day(s) of the week.
+                        example: "12:00"
                       validFrom:
                         type: string
                         description: The date when the item becomes valid.
@@ -4135,6 +5378,10 @@ components:
                           opening hours.
                 inLanguages:
                   type: array
+                  description: List of languages this object is available in.
+                  example:
+                    - de
+                    - en
                   items:
                     type: string
                 tags:
@@ -4149,13 +5396,16 @@ components:
                   type: array
                   items:
                     type: array
+                    description: Links to external resources related to this object.
                     items:
                       type: object
                       properties:
                         displayName:
                           type: string
+                          example: Website
                         url:
                           type: string
+                          example: https://example.com/
                       required:
                         - url
                 manager:
@@ -4169,15 +5419,29 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                      description: >-
+                        A string that can be translated into multiple languages,
+                        e.g. { "de": "Konzert", "en": "concert" }
+                      example:
+                        de: Konzert
+                        en: concert
+                  description: The managing person of this location.
                 contact:
                   type: object
+                  description: The main contact person of this location.
                   properties:
                     name:
                       type: string
+                      description: Full name of the contact person.
+                      example: Jane Doe
                     email:
                       type: string
+                      description: Email address of the contact person.
+                      example: someone@example.com
                     telephone:
                       type: string
+                      description: Phone number of the contact person.
+                      example: +49 30 12345678
             locationReference:
               type: object
               properties:
@@ -4189,6 +5453,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     UpdateLocationRequest:
@@ -4198,14 +5468,32 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         address:
@@ -4213,14 +5501,22 @@ components:
           properties:
             streetAddress:
               type: string
+              description: Street address (street name and house number)
+              example: Beispielstraße 1
             addressLocality:
               type: string
+              example: Berlin
             postalCode:
               type: string
+              example: 12345
             description:
               type: string
+              example: Main hall
         borough:
           type: string
+          description: >-
+            The Berlin district (or "außerhalb", if the event happens outside of
+            Berlin).
           enum:
             - Mitte
             - Friedrichshain-Kreuzberg
@@ -4240,14 +5536,20 @@ components:
           properties:
             latitude:
               type: string
+              example: "52.521008"
             longitude:
               type: string
+              example: "13.405954"
             coordinateSystem:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -4258,24 +5560,36 @@ components:
           type: array
           items:
             type: array
+            description: Links to external resources related to this object.
             items:
               type: object
               properties:
                 displayName:
                   type: string
+                  example: Website
                 url:
                   type: string
+                  example: https://example.com/
               required:
                 - url
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
     SetLocationManagerRequest:
       type: object
       properties:
@@ -4285,6 +5599,12 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
       required:
         - organizationIdentifier
     ClaimLocationRequest:
@@ -4321,123 +5641,292 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            events:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Event
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                events:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Event
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - event.published
+                          - event.unpublished
+                          - event.archived
+                      scheduleStatus:
                         type: string
-                      availableLanguages:
+                        enum:
+                          - event.cancelled
+                          - event.postponed
+                          - event.rescheduled
+                          - event.scheduled
+                      schedule:
+                        type: object
+                        properties:
+                          startDate:
+                            type: string
+                            description: >-
+                              The date (year, month, day) the event starts, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
+                          startTime:
+                            type: string
+                            description: >-
+                              The time the event starts, in timezone
+                              Europe/Berlin.
+                            example: "20:00:00"
+                          permanentOpening:
+                            type: boolean
+                            description: >-
+                              Indicates whether the event is permanently open
+                              (and has no end date/time).
+                            example: false
+                          doorTime:
+                            type: string
+                            description: >-
+                              The time that guests can enter the venue, in
+                              timezone Europe/Berlin.
+                            example: "19:00:00"
+                          endDate:
+                            type: string
+                            description: >-
+                              The date (year, month, day) the event ends, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
+                          endTime:
+                            type: string
+                            description: The time the event end, in timezone Europe/Berlin.
+                            example: "22:00"
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      pleaseNote:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
+                        type: string
+                        example: https://example.com/
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - event.published
-                      - event.unpublished
-                      - event.archived
-                  scheduleStatus:
-                    type: string
-                    enum:
-                      - event.cancelled
-                      - event.postponed
-                      - event.rescheduled
-                      - event.scheduled
-                  schedule:
-                    type: object
-                    properties:
-                      startDate:
-                        type: string
-                      startTime:
-                        type: string
-                      permanentOpening:
-                        type: boolean
-                      doorTime:
-                        type: string
-                      endDate:
-                        type: string
-                      endTime:
-                        type: string
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  pleaseNote:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  locations:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        referenceType:
-                          type: string
-                        referenceId:
-                          type: string
-                        referenceLabel:
+                      locations:
+                        type: array
+                        items:
                           type: object
-                          additionalProperties:
-                            type: string
-                  attractions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        referenceType:
-                          type: string
-                        referenceId:
-                          type: string
-                        referenceLabel:
+                          properties:
+                            referenceType:
+                              type: string
+                            referenceId:
+                              type: string
+                            referenceLabel:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                      attractions:
+                        type: array
+                        items:
                           type: object
-                          additionalProperties:
+                          properties:
+                            referenceType:
+                              type: string
+                            referenceId:
+                              type: string
+                            referenceLabel:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                      organizer:
+                        type: object
+                        properties:
+                          referenceType:
                             type: string
-                  organizer:
+                          referenceId:
+                            type: string
+                          referenceLabel:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                      contact:
+                        type: object
+                        description: >-
+                          A person that is connected to and/or responsible for
+                          the referenced entity.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                      admission:
+                        type: object
+                        description: >-
+                          Information about the admission to the
+                          event/attraction.
+                        properties:
+                          note:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                          ticketType:
+                            type: string
+                            enum:
+                              - ticketType.ticketRequired
+                              - ticketType.freeOfCharge
+                          registrationType:
+                            type: string
+                            enum:
+                              - registrationType.registrationRequired
+                              - registrationType.noRegistrationRequired
+                              - registrationType.registrationDesired
+                          admissionLink:
+                            type: string
+                            example: https://example.com/
+                eventsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
                       referenceType:
@@ -4448,48 +5937,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
-                  contact:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      email:
-                        type: string
-                      telephone:
-                        type: string
-                  admission:
-                    type: object
-                    properties:
-                      note:
-                        type: object
-                        additionalProperties:
-                          type: string
-                      ticketType:
-                        type: string
-                        enum:
-                          - ticketType.ticketRequired
-                          - ticketType.freeOfCharge
-                      registrationType:
-                        type: string
-                        enum:
-                          - registrationType.registrationRequired
-                          - registrationType.noRegistrationRequired
-                          - registrationType.registrationDesired
-                      admissionLink:
-                        type: string
-            eventsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     CreateEventRequest:
@@ -4504,36 +5957,84 @@ components:
           properties:
             startDate:
               type: string
+              description: >-
+                The date (year, month, day) the event starts, in timezone
+                Europe/Berlin.
+              example: "2023-09-08"
             startTime:
               type: string
+              description: The time the event starts, in timezone Europe/Berlin.
+              example: "20:00:00"
             permanentOpening:
               type: boolean
+              description: >-
+                Indicates whether the event is permanently open (and has no end
+                date/time).
+              example: false
             doorTime:
               type: string
+              description: >-
+                The time that guests can enter the venue, in timezone
+                Europe/Berlin.
+              example: "19:00:00"
             endDate:
               type: string
+              description: >-
+                The date (year, month, day) the event ends, in timezone
+                Europe/Berlin.
+              example: "2023-09-08"
             endTime:
               type: string
+              description: The time the event end, in timezone Europe/Berlin.
+              example: "22:00"
         title:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -4553,6 +6054,12 @@ components:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
         attractions:
           type: array
           items:
@@ -4566,6 +6073,12 @@ components:
                 type: object
                 additionalProperties:
                   type: string
+                description: >-
+                  A string that can be translated into multiple languages, e.g.
+                  { "de": "Konzert", "en": "concert" }
+                example:
+                  de: Konzert
+                  en: concert
         organizer:
           type: object
           properties:
@@ -4577,22 +6090,44 @@ components:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
         admission:
           type: object
+          description: Information about the admission to the event/attraction.
           properties:
             note:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
             ticketType:
               type: string
               enum:
@@ -4606,6 +6141,7 @@ components:
                 - registrationType.registrationDesired
             admissionLink:
               type: string
+              example: https://example.com/
         metadata:
           type: object
           properties:
@@ -4638,6 +6174,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     SearchEventsRequest:
@@ -4685,123 +6227,292 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            events:
-              type: array
-              items:
-                type: object
-                required:
-                  - identifier
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Event
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                events:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - identifier
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Event
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - event.published
+                          - event.unpublished
+                          - event.archived
+                      scheduleStatus:
                         type: string
-                      availableLanguages:
+                        enum:
+                          - event.cancelled
+                          - event.postponed
+                          - event.rescheduled
+                          - event.scheduled
+                      schedule:
+                        type: object
+                        properties:
+                          startDate:
+                            type: string
+                            description: >-
+                              The date (year, month, day) the event starts, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
+                          startTime:
+                            type: string
+                            description: >-
+                              The time the event starts, in timezone
+                              Europe/Berlin.
+                            example: "20:00:00"
+                          permanentOpening:
+                            type: boolean
+                            description: >-
+                              Indicates whether the event is permanently open
+                              (and has no end date/time).
+                            example: false
+                          doorTime:
+                            type: string
+                            description: >-
+                              The time that guests can enter the venue, in
+                              timezone Europe/Berlin.
+                            example: "19:00:00"
+                          endDate:
+                            type: string
+                            description: >-
+                              The date (year, month, day) the event ends, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
+                          endTime:
+                            type: string
+                            description: The time the event end, in timezone Europe/Berlin.
+                            example: "22:00"
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      pleaseNote:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
+                        type: string
+                        example: https://example.com/
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - event.published
-                      - event.unpublished
-                      - event.archived
-                  scheduleStatus:
-                    type: string
-                    enum:
-                      - event.cancelled
-                      - event.postponed
-                      - event.rescheduled
-                      - event.scheduled
-                  schedule:
-                    type: object
-                    properties:
-                      startDate:
-                        type: string
-                      startTime:
-                        type: string
-                      permanentOpening:
-                        type: boolean
-                      doorTime:
-                        type: string
-                      endDate:
-                        type: string
-                      endTime:
-                        type: string
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  pleaseNote:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  locations:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        referenceType:
-                          type: string
-                        referenceId:
-                          type: string
-                        referenceLabel:
+                      locations:
+                        type: array
+                        items:
                           type: object
-                          additionalProperties:
-                            type: string
-                  attractions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        referenceType:
-                          type: string
-                        referenceId:
-                          type: string
-                        referenceLabel:
+                          properties:
+                            referenceType:
+                              type: string
+                            referenceId:
+                              type: string
+                            referenceLabel:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                      attractions:
+                        type: array
+                        items:
                           type: object
-                          additionalProperties:
+                          properties:
+                            referenceType:
+                              type: string
+                            referenceId:
+                              type: string
+                            referenceLabel:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                      organizer:
+                        type: object
+                        properties:
+                          referenceType:
                             type: string
-                  organizer:
+                          referenceId:
+                            type: string
+                          referenceLabel:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                      contact:
+                        type: object
+                        description: >-
+                          A person that is connected to and/or responsible for
+                          the referenced entity.
+                        properties:
+                          name:
+                            type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
+                          email:
+                            type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
+                          telephone:
+                            type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
+                      admission:
+                        type: object
+                        description: >-
+                          Information about the admission to the
+                          event/attraction.
+                        properties:
+                          note:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
+                          ticketType:
+                            type: string
+                            enum:
+                              - ticketType.ticketRequired
+                              - ticketType.freeOfCharge
+                          registrationType:
+                            type: string
+                            enum:
+                              - registrationType.registrationRequired
+                              - registrationType.noRegistrationRequired
+                              - registrationType.registrationDesired
+                          admissionLink:
+                            type: string
+                            example: https://example.com/
+                eventsReferences:
+                  type: array
+                  items:
                     type: object
                     properties:
                       referenceType:
@@ -4812,48 +6523,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
-                  contact:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      email:
-                        type: string
-                      telephone:
-                        type: string
-                  admission:
-                    type: object
-                    properties:
-                      note:
-                        type: object
-                        additionalProperties:
-                          type: string
-                      ticketType:
-                        type: string
-                        enum:
-                          - ticketType.ticketRequired
-                          - ticketType.freeOfCharge
-                      registrationType:
-                        type: string
-                        enum:
-                          - registrationType.registrationRequired
-                          - registrationType.noRegistrationRequired
-                          - registrationType.registrationDesired
-                      admissionLink:
-                        type: string
-            eventsReferences:
-              type: array
-              items:
-                type: object
-                properties:
-                  referenceType:
-                    type: string
-                  referenceId:
-                    type: string
-                  referenceLabel:
-                    type: object
-                    additionalProperties:
-                      type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
       required:
         - success
     GetEventResponse:
@@ -4879,17 +6554,36 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
+                      description: >-
+                        The date and time the object was created (ISO
+                        timestamp).
+                      example: "2011-10-05T14:48:00.000Z"
                     updated:
                       type: string
+                      description: >-
+                        The date and time the object was last updated (ISO
+                        timestamp). Is identical to created date after first
+                        creation.
+                      example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
+                      description: The source of this object.
+                      example: bezirkskalender
                     originObjectID:
                       type: string
+                      description: The original ID of this object in the original system.
                     availableLanguages:
                       type: array
+                      description: List of languages this object is available in.
+                      example:
+                        - de
+                        - en
                       items:
                         type: string
                 status:
@@ -4910,36 +6604,85 @@ components:
                   properties:
                     startDate:
                       type: string
+                      description: >-
+                        The date (year, month, day) the event starts, in
+                        timezone Europe/Berlin.
+                      example: "2023-09-08"
                     startTime:
                       type: string
+                      description: The time the event starts, in timezone Europe/Berlin.
+                      example: "20:00:00"
                     permanentOpening:
                       type: boolean
+                      description: >-
+                        Indicates whether the event is permanently open (and has
+                        no end date/time).
+                      example: false
                     doorTime:
                       type: string
+                      description: >-
+                        The time that guests can enter the venue, in timezone
+                        Europe/Berlin.
+                      example: "19:00:00"
                     endDate:
                       type: string
+                      description: >-
+                        The date (year, month, day) the event ends, in timezone
+                        Europe/Berlin.
+                      example: "2023-09-08"
                     endTime:
                       type: string
+                      description: The time the event end, in timezone Europe/Berlin.
+                      example: "22:00"
                 title:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 displayName:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 description:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 pleaseNote:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 website:
                   type: string
+                  example: https://example.com/
                 inLanguages:
                   type: array
+                  description: List of languages this object is available in.
+                  example:
+                    - de
+                    - en
                   items:
                     type: string
                 tags:
@@ -4959,6 +6702,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                 attractions:
                   type: array
                   items:
@@ -4972,6 +6721,12 @@ components:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                 organizer:
                   type: object
                   properties:
@@ -4983,22 +6738,44 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                      description: >-
+                        A string that can be translated into multiple languages,
+                        e.g. { "de": "Konzert", "en": "concert" }
+                      example:
+                        de: Konzert
+                        en: concert
                 contact:
                   type: object
+                  description: >-
+                    A person that is connected to and/or responsible for the
+                    referenced entity.
                   properties:
                     name:
                       type: string
+                      description: Full name of the contact person.
+                      example: Jane Doe
                     email:
                       type: string
+                      description: Email address of the contact person.
+                      example: someone@example.com
                     telephone:
                       type: string
+                      description: Phone number of the contact person.
+                      example: +49 30 12345678
                 admission:
                   type: object
+                  description: Information about the admission to the event/attraction.
                   properties:
                     note:
                       type: object
                       additionalProperties:
                         type: string
+                      description: >-
+                        A string that can be translated into multiple languages,
+                        e.g. { "de": "Konzert", "en": "concert" }
+                      example:
+                        de: Konzert
+                        en: concert
                     ticketType:
                       type: string
                       enum:
@@ -5012,6 +6789,7 @@ components:
                         - registrationType.registrationDesired
                     admissionLink:
                       type: string
+                      example: https://example.com/
             eventReference:
               type: object
               properties:
@@ -5023,6 +6801,12 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
       required:
         - success
     UpdateEventRequest:
@@ -5032,22 +6816,50 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         displayName:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         description:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         pleaseNote:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         website:
           type: string
         inLanguages:
           type: array
+          description: List of languages this object is available in.
+          example:
+            - de
+            - en
           items:
             type: string
         tags:
@@ -5056,20 +6868,36 @@ components:
             type: string
         contact:
           type: object
+          description: >-
+            A person that is connected to and/or responsible for the referenced
+            entity.
           properties:
             name:
               type: string
+              description: Full name of the contact person.
+              example: Jane Doe
             email:
               type: string
+              description: Email address of the contact person.
+              example: someone@example.com
             telephone:
               type: string
+              description: Phone number of the contact person.
+              example: +49 30 12345678
         admission:
           type: object
+          description: Information about the admission to the event/attraction.
           properties:
             note:
               type: object
               additionalProperties:
                 type: string
+              description: >-
+                A string that can be translated into multiple languages, e.g. {
+                "de": "Konzert", "en": "concert" }
+              example:
+                de: Konzert
+                en: concert
             ticketType:
               type: string
               enum:
@@ -5083,6 +6911,7 @@ components:
                 - registrationType.registrationDesired
             admissionLink:
               type: string
+              example: https://example.com/
     AddEventLocationRequest:
       type: object
       properties:
@@ -5092,6 +6921,12 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
     RemoveEventLocationRequest:
       type: object
       properties:
@@ -5108,6 +6943,12 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
     RemoveEventAttractionRequest:
       type: object
       properties:
@@ -5124,6 +6965,12 @@ components:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
     RescheduleEventRequest:
       type: object
       properties:
@@ -5172,6 +7019,10 @@ components:
           type: string
         data:
           type: object
+          required:
+            - accessToken
+            - expiresIn
+            - user
           properties:
             accessToken:
               type: string
@@ -5214,43 +7065,57 @@ components:
         message:
           type: string
         data:
-          type: object
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            users:
-              type: array
-              items:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - User
-                  identifier:
-                    type: string
-                  email:
-                    type: string
-                  password:
-                    type: string
-                  firstName:
-                    type: string
-                  lastName:
-                    type: string
-                  createdAt:
-                    type: string
-                  updatedAt:
-                    type: string
-                  permissionFlags:
-                    type: number
-                required:
-                  - identifier
-                  - email
-                  - permissionFlags
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              properties:
+                users:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - User
+                      identifier:
+                        type: string
+                      email:
+                        type: string
+                      password:
+                        type: string
+                      firstName:
+                        type: string
+                      lastName:
+                        type: string
+                      createdAt:
+                        type: string
+                      updatedAt:
+                        type: string
+                      permissionFlags:
+                        type: number
+                    required:
+                      - identifier
+                      - email
+                      - permissionFlags
       required:
         - success
     CreateUserRequest:
@@ -5385,20 +7250,47 @@ components:
                     type: object
                     additionalProperties:
                       type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
                   metadata:
                     allOf:
                       - type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
                           updated:
                             type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
+                            description: The source of this object.
+                            example: bezirkskalender
                           originObjectID:
                             type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
                           availableLanguages:
                             type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
                             items:
                               type: string
                       - type: object
@@ -5435,20 +7327,47 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 metadata:
                   allOf:
                     - type: object
+                      required:
+                        - created
+                        - updated
                       properties:
                         created:
                           type: string
+                          description: >-
+                            The date and time the object was created (ISO
+                            timestamp).
+                          example: "2011-10-05T14:48:00.000Z"
                         updated:
                           type: string
+                          description: >-
+                            The date and time the object was last updated (ISO
+                            timestamp). Is identical to created date after first
+                            creation.
+                          example: "2011-10-05T14:48:00.000Z"
                         origin:
                           type: string
+                          description: The source of this object.
+                          example: bezirkskalender
                         originObjectID:
                           type: string
+                          description: >-
+                            The original ID of this object in the original
+                            system.
                         availableLanguages:
                           type: array
+                          description: List of languages this object is available in.
+                          example:
+                            - de
+                            - en
                           items:
                             type: string
                     - type: object
@@ -5465,40 +7384,22 @@ components:
     CreateTagRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Tag
-        identifier:
-          type: string
         title:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            A string that can be translated into multiple languages, e.g. {
+            "de": "Konzert", "en": "concert" }
+          example:
+            de: Konzert
+            en: concert
         metadata:
-          allOf:
-            - type: object
-              properties:
-                created:
-                  type: string
-                updated:
-                  type: string
-                origin:
-                  type: string
-                originObjectID:
-                  type: string
-                availableLanguages:
-                  type: array
-                  items:
-                    type: string
-            - type: object
-              properties:
-                externalIDs:
-                  type: object
-                  additionalProperties:
-                    type: string
+          type: object
+          properties:
+            externalIDs:
+              type: object
       required:
-        - identifier
         - title
     CreateTagResponse:
       properties:
@@ -5524,20 +7425,47 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 metadata:
                   allOf:
                     - type: object
+                      required:
+                        - created
+                        - updated
                       properties:
                         created:
                           type: string
+                          description: >-
+                            The date and time the object was created (ISO
+                            timestamp).
+                          example: "2011-10-05T14:48:00.000Z"
                         updated:
                           type: string
+                          description: >-
+                            The date and time the object was last updated (ISO
+                            timestamp). Is identical to created date after first
+                            creation.
+                          example: "2011-10-05T14:48:00.000Z"
                         origin:
                           type: string
+                          description: The source of this object.
+                          example: bezirkskalender
                         originObjectID:
                           type: string
+                          description: >-
+                            The original ID of this object in the original
+                            system.
                         availableLanguages:
                           type: array
+                          description: List of languages this object is available in.
+                          example:
+                            - de
+                            - en
                           items:
                             type: string
                     - type: object
@@ -5578,17 +7506,36 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
+                      description: >-
+                        The date and time the object was created (ISO
+                        timestamp).
+                      example: "2011-10-05T14:48:00.000Z"
                     updated:
                       type: string
+                      description: >-
+                        The date and time the object was last updated (ISO
+                        timestamp). Is identical to created date after first
+                        creation.
+                      example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
+                      description: The source of this object.
+                      example: bezirkskalender
                     originObjectID:
                       type: string
+                      description: The original ID of this object in the original system.
                     availableLanguages:
                       type: array
+                      description: List of languages this object is available in.
+                      example:
+                        - de
+                        - en
                       items:
                         type: string
                 status:
@@ -5601,22 +7548,50 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 displayName:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 description:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 pleaseNote:
                   type: object
                   additionalProperties:
                     type: string
+                  description: >-
+                    A string that can be translated into multiple languages,
+                    e.g. { "de": "Konzert", "en": "concert" }
+                  example:
+                    de: Konzert
+                    en: concert
                 website:
                   type: string
                 inLanguages:
                   type: array
+                  description: List of languages this object is available in.
+                  example:
+                    - de
+                    - en
                   items:
                     type: string
                 tags:
@@ -5638,17 +7613,38 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
                           updated:
                             type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
+                            description: The source of this object.
+                            example: bezirkskalender
                           originObjectID:
                             type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
                           availableLanguages:
                             type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
                             items:
                               type: string
                       status:
@@ -5669,36 +7665,87 @@ components:
                         properties:
                           startDate:
                             type: string
+                            description: >-
+                              The date (year, month, day) the event starts, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
                           startTime:
                             type: string
+                            description: >-
+                              The time the event starts, in timezone
+                              Europe/Berlin.
+                            example: "20:00:00"
                           permanentOpening:
                             type: boolean
+                            description: >-
+                              Indicates whether the event is permanently open
+                              (and has no end date/time).
+                            example: false
                           doorTime:
                             type: string
+                            description: >-
+                              The time that guests can enter the venue, in
+                              timezone Europe/Berlin.
+                            example: "19:00:00"
                           endDate:
                             type: string
+                            description: >-
+                              The date (year, month, day) the event ends, in
+                              timezone Europe/Berlin.
+                            example: "2023-09-08"
                           endTime:
                             type: string
+                            description: The time the event end, in timezone Europe/Berlin.
+                            example: "22:00"
                       title:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                       displayName:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                       description:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                       pleaseNote:
                         type: object
                         additionalProperties:
                           type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
                       website:
                         type: string
+                        example: https://example.com/
                       inLanguages:
                         type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
                         items:
                           type: string
                       tags:
@@ -5718,6 +7765,13 @@ components:
                               type: object
                               additionalProperties:
                                 type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
                       attractions:
                         type: array
                         items:
@@ -5731,6 +7785,13 @@ components:
                               type: object
                               additionalProperties:
                                 type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
                       organizer:
                         type: object
                         properties:
@@ -5742,22 +7803,48 @@ components:
                             type: object
                             additionalProperties:
                               type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
                       contact:
                         type: object
+                        description: >-
+                          A person that is connected to and/or responsible for
+                          the referenced entity.
                         properties:
                           name:
                             type: string
+                            description: Full name of the contact person.
+                            example: Jane Doe
                           email:
                             type: string
+                            description: Email address of the contact person.
+                            example: someone@example.com
                           telephone:
                             type: string
+                            description: Phone number of the contact person.
+                            example: +49 30 12345678
                       admission:
                         type: object
+                        description: >-
+                          Information about the admission to the
+                          event/attraction.
                         properties:
                           note:
                             type: object
                             additionalProperties:
                               type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Konzert
+                              en: concert
                           ticketType:
                             type: string
                             enum:
@@ -5771,15 +7858,19 @@ components:
                               - registrationType.registrationDesired
                           admissionLink:
                             type: string
+                            example: https://example.com/
                 externalLinks:
                   type: array
+                  description: Links to external resources related to this object.
                   items:
                     type: object
                     properties:
                       displayName:
                         type: string
+                        example: Website
                       url:
                         type: string
+                        example: https://example.com/
                     required:
                       - url
       required:
@@ -5792,242 +7883,436 @@ components:
         message:
           type: string
         data:
-          type: object
-          required:
-            - page
-            - pageSize
-            - totalCount
-            - attractions
-          properties:
-            page:
-              type: number
-            pageSize:
-              type: number
-            totalCount:
-              type: number
-            attractions:
-              type: array
-              items:
-                type: object
-                required:
-                  - type
-                  - identifier
-                  - metadata
-                  - title
-                  - events
-                properties:
-                  type:
-                    type: string
-                    enum:
-                      - type.Attraction
-                  identifier:
-                    type: string
-                  metadata:
+          allOf:
+            - type: object
+              description: Metadata for paginated lists.
+              properties:
+                page:
+                  type: number
+                  description: The current page, starting with 1
+                  example: 1
+                pageSize:
+                  type: number
+                  description: The number of items per page
+                  example: 30
+                totalCount:
+                  type: number
+                  description: The total number of items
+                  example: 105
+              required:
+                - page
+                - pageSize
+                - totalCount
+            - type: object
+              required:
+                - attractions
+              properties:
+                attractions:
+                  type: array
+                  items:
                     type: object
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                      - events
                     properties:
-                      created:
+                      type:
                         type: string
-                      updated:
+                        enum:
+                          - type.Attraction
+                      identifier:
                         type: string
-                      origin:
+                      metadata:
+                        type: object
+                        required:
+                          - created
+                          - updated
+                        properties:
+                          created:
+                            type: string
+                            description: >-
+                              The date and time the object was created (ISO
+                              timestamp).
+                            example: "2011-10-05T14:48:00.000Z"
+                          updated:
+                            type: string
+                            description: >-
+                              The date and time the object was last updated (ISO
+                              timestamp). Is identical to created date after
+                              first creation.
+                            example: "2011-10-05T14:48:00.000Z"
+                          origin:
+                            type: string
+                            description: The source of this object.
+                            example: bezirkskalender
+                          originObjectID:
+                            type: string
+                            description: >-
+                              The original ID of this object in the original
+                              system.
+                          availableLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                      status:
                         type: string
-                      originObjectID:
+                        enum:
+                          - attraction.published
+                          - attraction.unpublished
+                          - attraction.archived
+                      title:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      displayName:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      description:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      pleaseNote:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      website:
                         type: string
-                      availableLanguages:
+                      inLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      tags:
                         type: array
                         items:
                           type: string
-                  status:
-                    type: string
-                    enum:
-                      - attraction.published
-                      - attraction.unpublished
-                      - attraction.archived
-                  title:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  displayName:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  description:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  pleaseNote:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  website:
-                    type: string
-                  inLanguages:
-                    type: array
-                    items:
-                      type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  events:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - identifier
-                      properties:
-                        type:
-                          type: string
-                          enum:
-                            - type.Event
-                        identifier:
-                          type: string
-                        metadata:
+                      events:
+                        type: array
+                        items:
                           type: object
+                          required:
+                            - identifier
                           properties:
-                            created:
+                            type:
                               type: string
-                            updated:
+                              enum:
+                                - type.Event
+                            identifier:
                               type: string
-                            origin:
+                            metadata:
+                              type: object
+                              required:
+                                - created
+                                - updated
+                              properties:
+                                created:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was created
+                                    (ISO timestamp).
+                                  example: "2011-10-05T14:48:00.000Z"
+                                updated:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was last
+                                    updated (ISO timestamp). Is identical to
+                                    created date after first creation.
+                                  example: "2011-10-05T14:48:00.000Z"
+                                origin:
+                                  type: string
+                                  description: The source of this object.
+                                  example: bezirkskalender
+                                originObjectID:
+                                  type: string
+                                  description: >-
+                                    The original ID of this object in the
+                                    original system.
+                                availableLanguages:
+                                  type: array
+                                  description: >-
+                                    List of languages this object is available
+                                    in.
+                                  example:
+                                    - de
+                                    - en
+                                  items:
+                                    type: string
+                            status:
                               type: string
-                            originObjectID:
+                              enum:
+                                - event.published
+                                - event.unpublished
+                                - event.archived
+                            scheduleStatus:
                               type: string
-                            availableLanguages:
+                              enum:
+                                - event.cancelled
+                                - event.postponed
+                                - event.rescheduled
+                                - event.scheduled
+                            schedule:
+                              type: object
+                              properties:
+                                startDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event
+                                    starts, in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                startTime:
+                                  type: string
+                                  description: >-
+                                    The time the event starts, in timezone
+                                    Europe/Berlin.
+                                  example: "20:00:00"
+                                permanentOpening:
+                                  type: boolean
+                                  description: >-
+                                    Indicates whether the event is permanently
+                                    open (and has no end date/time).
+                                  example: false
+                                doorTime:
+                                  type: string
+                                  description: >-
+                                    The time that guests can enter the venue, in
+                                    timezone Europe/Berlin.
+                                  example: "19:00:00"
+                                endDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event ends,
+                                    in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                endTime:
+                                  type: string
+                                  description: >-
+                                    The time the event end, in timezone
+                                    Europe/Berlin.
+                                  example: "22:00"
+                            title:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            displayName:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            description:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            pleaseNote:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            website:
+                              type: string
+                              example: https://example.com/
+                            inLanguages:
+                              type: array
+                              description: List of languages this object is available in.
+                              example:
+                                - de
+                                - en
+                              items:
+                                type: string
+                            tags:
                               type: array
                               items:
                                 type: string
-                        status:
-                          type: string
-                          enum:
-                            - event.published
-                            - event.unpublished
-                            - event.archived
-                        scheduleStatus:
-                          type: string
-                          enum:
-                            - event.cancelled
-                            - event.postponed
-                            - event.rescheduled
-                            - event.scheduled
-                        schedule:
-                          type: object
-                          properties:
-                            startDate:
-                              type: string
-                            startTime:
-                              type: string
-                            permanentOpening:
-                              type: boolean
-                            doorTime:
-                              type: string
-                            endDate:
-                              type: string
-                            endTime:
-                              type: string
-                        title:
-                          type: object
-                          additionalProperties:
-                            type: string
-                        displayName:
-                          type: object
-                          additionalProperties:
-                            type: string
-                        description:
-                          type: object
-                          additionalProperties:
-                            type: string
-                        pleaseNote:
-                          type: object
-                          additionalProperties:
-                            type: string
-                        website:
-                          type: string
-                        inLanguages:
-                          type: array
-                          items:
-                            type: string
-                        tags:
-                          type: array
-                          items:
-                            type: string
-                        locations:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              referenceType:
-                                type: string
-                              referenceId:
-                                type: string
-                              referenceLabel:
+                            locations:
+                              type: array
+                              items:
                                 type: object
-                                additionalProperties:
-                                  type: string
-                        attractions:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              referenceType:
-                                type: string
-                              referenceId:
-                                type: string
-                              referenceLabel:
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                            attractions:
+                              type: array
+                              items:
                                 type: object
-                                additionalProperties:
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                            organizer:
+                              type: object
+                              properties:
+                                referenceType:
                                   type: string
-                        organizer:
-                          type: object
-                          properties:
-                            referenceType:
-                              type: string
-                            referenceId:
-                              type: string
-                            referenceLabel:
+                                referenceId:
+                                  type: string
+                                referenceLabel:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                            contact:
                               type: object
-                              additionalProperties:
-                                type: string
-                        contact:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            email:
-                              type: string
-                            telephone:
-                              type: string
-                        admission:
-                          type: object
-                          properties:
-                            note:
+                              description: >-
+                                A person that is connected to and/or responsible
+                                for the referenced entity.
+                              properties:
+                                name:
+                                  type: string
+                                  description: Full name of the contact person.
+                                  example: Jane Doe
+                                email:
+                                  type: string
+                                  description: Email address of the contact person.
+                                  example: someone@example.com
+                                telephone:
+                                  type: string
+                                  description: Phone number of the contact person.
+                                  example: +49 30 12345678
+                            admission:
                               type: object
-                              additionalProperties:
-                                type: string
-                            ticketType:
+                              description: >-
+                                Information about the admission to the
+                                event/attraction.
+                              properties:
+                                note:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                                ticketType:
+                                  type: string
+                                  enum:
+                                    - ticketType.ticketRequired
+                                    - ticketType.freeOfCharge
+                                registrationType:
+                                  type: string
+                                  enum:
+                                    - registrationType.registrationRequired
+                                    - registrationType.noRegistrationRequired
+                                    - registrationType.registrationDesired
+                                admissionLink:
+                                  type: string
+                                  example: https://example.com/
+                      externalLinks:
+                        type: array
+                        description: Links to external resources related to this object.
+                        items:
+                          type: object
+                          properties:
+                            displayName:
                               type: string
-                              enum:
-                                - ticketType.ticketRequired
-                                - ticketType.freeOfCharge
-                            registrationType:
+                              example: Website
+                            url:
                               type: string
-                              enum:
-                                - registrationType.registrationRequired
-                                - registrationType.noRegistrationRequired
-                                - registrationType.registrationDesired
-                            admissionLink:
-                              type: string
-                  externalLinks:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        displayName:
-                          type: string
-                        url:
-                          type: string
-                      required:
-                        - url
+                              example: https://example.com/
+                          required:
+                            - url
       required:
         - success
         - data
+    TranslatableField:
+      type: object
+      additionalProperties:
+        type: string
+      description: >-
+        A string that can be translated into multiple languages, e.g. { "de":
+        "Konzert", "en": "concert" }
+      example:
+        de: Konzert
+        en: concert

--- a/src/components/AttractionEditor/index.tsx
+++ b/src/components/AttractionEditor/index.tsx
@@ -34,9 +34,9 @@ export default function AttractionEditor(props: Props) {
 			}
 			const apiClient = createAuthorizedClient(accessToken);
 			if (isNew) {
-				await apiClient.maintainCulturalData.postAttractions(attractionRequest);
+				await apiClient.manageCulturalData.postAttractions(attractionRequest);
 			} else {
-				await apiClient.maintainCulturalData.patchAttractions(attraction.identifier, attractionRequest);
+				await apiClient.manageCulturalData.patchAttractions(attraction.identifier, attractionRequest);
 			}
 			onAfterSubmit();
 		},

--- a/src/components/LocationTable/LocationTableRow.tsx
+++ b/src/components/LocationTable/LocationTableRow.tsx
@@ -9,7 +9,7 @@ interface LocationTableRowProps {
 const LocationTableRow: FC<LocationTableRowProps> = ({ location }: LocationTableRowProps) => {
 	const deleteLocation = (/* identifier: string */) => {
 		// TODO: Deleting locations is not yet implemented on API side.
-		// apiClient.maintainCulturalData
+		// apiClient.manageCulturalData
 		// 	.deleteLocations(identifier)
 		// 	.then(() => {
 		// 		console.log('Location deleted successfully');

--- a/src/components/OrganizationTable/OrganizationTableRow.tsx
+++ b/src/components/OrganizationTable/OrganizationTableRow.tsx
@@ -9,7 +9,7 @@ interface OrganizationTableRowProps {
 const OrganizationTableRow: FC<OrganizationTableRowProps> = ({ organization }: OrganizationTableRowProps) => {
 	const deleteOrganization = (/* identifier: string */) => {
 		// TODO: Deleting organizations is not yet implemented on API side.
-		// apiClient.maintainCulturalData
+		// apiClient.manageCulturalData
 		// 	.deleteOrganizations(identifier)
 		// 	.then(() => {
 		// 		console.log('Organization deleted successfully');

--- a/src/pages/admin/locations/[identifier].tsx
+++ b/src/pages/admin/locations/[identifier].tsx
@@ -39,7 +39,7 @@ const LocationDetails = () => {
 	}, [identifier, fetchLocation]);
 
 	const editLocation = async (locationObject: Location) => {
-		await apiClient.maintainCulturalData.patchLocations(identifier as string, locationObject as UpdateLocationRequest);
+		await apiClient.manageCulturalData.patchLocations(identifier as string, locationObject as UpdateLocationRequest);
 		fetchLocation();
 		router.push(ROUTES.admin.locationDetails(identifier!));
 	};

--- a/src/pages/admin/locations/create.tsx
+++ b/src/pages/admin/locations/create.tsx
@@ -26,7 +26,7 @@ const CreateNewLocation = () => {
 
 	const createLocationHandler = (e: FormEvent<HTMLFormElement>, newLocation: Location) => {
 		e.preventDefault();
-		apiClient.maintainCulturalData
+		apiClient.manageCulturalData
 			.postLocations(newLocation as CreateLocationRequest)
 			.then((res) => {
 				const id = res.data!.locationReference!.referenceId!;

--- a/src/pages/admin/organizations/[identifier].tsx
+++ b/src/pages/admin/organizations/[identifier].tsx
@@ -39,7 +39,7 @@ const OrganizationDetails = () => {
 	}, [identifier, fetchOrganization]);
 
 	const editOrganization = (organizationObject: Organization) => {
-		apiClient.maintainCulturalData
+		apiClient.manageCulturalData
 			.patchOrganizations(identifier!, organizationObject as UpdateOrganizationRequest)
 			.then(() => {
 				fetchOrganization();

--- a/src/pages/admin/organizations/create.tsx
+++ b/src/pages/admin/organizations/create.tsx
@@ -20,7 +20,7 @@ const CreateNewOrganization: FC = () => {
 	const [errorMessage, errorMessageSet] = useState<string | undefined>(undefined);
 	const createOrganizationHandler = (e: FormEvent<HTMLFormElement>, newOrganization: CreateOrganizationRequest) => {
 		e.preventDefault();
-		apiClient.maintainCulturalData
+		apiClient.manageCulturalData
 			.postOrganizations(newOrganization)
 			.then((/* res */) => {
 				// TODO: Navigate to created organization.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
 	const { page, pageSize } = getPagination(context.query);
-	const response = await apiClient.discoverCulturalData.getAttractions(false, page, pageSize);
+	const response = await apiClient.discoverCulturalData.getAttractions(page, pageSize, false);
 	const data = response.data!;
 	const attractions = data.attractions || [];
 	const pagination: PaginationType = {


### PR DESCRIPTION
Uses the new openAPI file generated after https://github.com/technologiestiftung/kulturdaten-api/pull/62 and https://github.com/technologiestiftung/kulturdaten-api/pull/63 and migrates the changed routes/parameters.