### PR TITLE
feat: show created and updated dates in attraction overview

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -27,6 +27,8 @@
 		"table-header-title": "Angebotstitel",
 		"table-header-events": "Termine",
 		"table-header-status": "Status",
+		"table-header-created": "Erstellt",
+		"table-header-updated": "Bearbeitet",
 		"table-option-edit": "Bearbeiten",
 		"table-option-delete": "Löschen",
 		"number-attractions": "{count, plural, =1 {# Angebot} other {# Angebote}}"

--- a/openAPI-specs.yml
+++ b/openAPI-specs.yml
@@ -1512,6 +1512,10 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - referenceType
+        - referenceId
+      additionalProperties: false
     Response:
       type: object
       properties:
@@ -1530,8 +1534,10 @@ components:
               type: string
             details:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     Error:
       type: object
       properties:
@@ -1541,6 +1547,7 @@ components:
           type: string
         details:
           type: string
+      additionalProperties: false
     NotFoundError:
       type: object
       properties:
@@ -1550,10 +1557,9 @@ components:
           type: string
         details:
           type: string
+      additionalProperties: false
     Event:
       type: object
-      required:
-        - identifier
       properties:
         type:
           type: string
@@ -1563,9 +1569,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -1592,6 +1595,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -1640,6 +1647,7 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          additionalProperties: false
         title:
           type: object
           additionalProperties:
@@ -1704,6 +1712,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         attractions:
           type: array
           items:
@@ -1723,6 +1735,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         organizer:
           type: object
           properties:
@@ -1740,6 +1756,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -1758,6 +1778,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -1786,14 +1807,14 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
-    AdminAttraction:
-      type: object
+          additionalProperties: false
       required:
         - type
         - identifier
         - metadata
-        - title
-        - events
+      additionalProperties: false
+    AdminAttraction:
+      type: object
       properties:
         type:
           type: string
@@ -1803,9 +1824,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -1832,6 +1850,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -1886,8 +1908,6 @@ components:
           type: array
           items:
             type: object
-            required:
-              - identifier
             properties:
               type:
                 type: string
@@ -1897,9 +1917,6 @@ components:
                 type: string
               metadata:
                 type: object
-                required:
-                  - created
-                  - updated
                 properties:
                   created:
                     type: string
@@ -1927,6 +1944,10 @@ components:
                       - en
                     items:
                       type: string
+                required:
+                  - created
+                  - updated
+                additionalProperties: false
               status:
                 type: string
                 enum:
@@ -1975,6 +1996,7 @@ components:
                     type: string
                     description: The time the event end, in timezone Europe/Berlin.
                     example: "22:00"
+                additionalProperties: false
               title:
                 type: object
                 additionalProperties:
@@ -2039,6 +2061,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
               attractions:
                 type: array
                 items:
@@ -2058,6 +2084,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
               organizer:
                 type: object
                 properties:
@@ -2075,6 +2105,10 @@ components:
                     example:
                       de: Konzert
                       en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
               contact:
                 type: object
                 description: >-
@@ -2093,6 +2127,7 @@ components:
                     type: string
                     description: Phone number of the contact person.
                     example: +49 30 12345678
+                additionalProperties: false
               admission:
                 type: object
                 description: Information about the admission to the event/attraction.
@@ -2121,6 +2156,12 @@ components:
                   admissionLink:
                     type: string
                     example: https://example.com/
+                additionalProperties: false
+            required:
+              - type
+              - identifier
+              - metadata
+            additionalProperties: false
         externalLinks:
           type: array
           description: Links to external resources related to this object.
@@ -2135,13 +2176,16 @@ components:
                 example: https://example.com/
             required:
               - url
-    Attraction:
-      type: object
+            additionalProperties: false
       required:
         - type
         - identifier
         - metadata
         - title
+        - events
+      additionalProperties: false
+    Attraction:
+      type: object
       properties:
         type:
           type: string
@@ -2151,9 +2195,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2180,6 +2221,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2242,10 +2287,15 @@ components:
                 example: https://example.com/
             required:
               - url
+            additionalProperties: false
+      required:
+        - type
+        - identifier
+        - metadata
+        - title
+      additionalProperties: false
     Location:
       type: object
-      required:
-        - identifier
       properties:
         type:
           type: string
@@ -2255,9 +2305,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2284,6 +2331,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2329,6 +2380,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -2361,6 +2413,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         openingStatus:
           type: string
           enum:
@@ -2372,12 +2428,6 @@ components:
           items:
             type: object
             properties:
-              closes:
-                type: string
-                description: >-
-                  The closing hour of the place or service on the given day(s)
-                  of the week.
-                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -2392,9 +2442,15 @@ components:
               opens:
                 type: string
                 description: >-
-                  The opening hour of the place or service on the given day(s)
-                  of the week.
+                  The opening hour of the place or service on the given day of
+                  the week.
                 example: "12:00"
+              closes:
+                type: string
+                description: >-
+                  The closing hour of the place or service on the given day of
+                  the week.
+                example: "22:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -2403,6 +2459,11 @@ components:
                 description: >-
                   The date after when the item is not valid. For example the end
                   of an offer, salary period, or a period of opening hours.
+            required:
+              - dayOfWeek
+              - opens
+              - closes
+            additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -2435,6 +2496,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         manager:
           type: object
           properties:
@@ -2452,6 +2514,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
           description: The managing person of this location.
         contact:
           type: object
@@ -2469,10 +2535,15 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      required:
+        - type
+        - identifier
+        - metadata
+        - title
+      additionalProperties: false
     Organization:
       type: object
-      required:
-        - identifier
       properties:
         type:
           type: string
@@ -2482,9 +2553,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2511,6 +2579,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2574,6 +2646,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -2606,6 +2679,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -2624,6 +2701,13 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      required:
+        - type
+        - identifier
+        - metadata
+        - title
+      additionalProperties: false
     User:
       type: object
       properties:
@@ -2648,9 +2732,13 @@ components:
         permissionFlags:
           type: number
       required:
+        - type
         - identifier
         - email
+        - createdAt
+        - updatedAt
         - permissionFlags
+      additionalProperties: false
     UpdateUserPasswordRequest:
       type: object
       properties:
@@ -2658,6 +2746,10 @@ components:
           type: string
         newPassword:
           type: string
+      required:
+        - oneTimeCode
+        - newPassword
+      additionalProperties: false
     HealthResponse:
       type: object
       properties:
@@ -2672,6 +2764,10 @@ components:
                 type: string
               healthy:
                 type: boolean
+            additionalProperties: false
+      required:
+        - healthy
+      additionalProperties: false
     AddExternalLinkRequest:
       type: object
       properties:
@@ -2681,6 +2777,7 @@ components:
           type: string
       required:
         - url
+      additionalProperties: false
     GetOrganizationResponse:
       type: object
       properties:
@@ -2693,8 +2790,6 @@ components:
           properties:
             organization:
               type: object
-              required:
-                - identifier
               properties:
                 type:
                   type: string
@@ -2704,9 +2799,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -2736,6 +2828,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -2799,6 +2895,7 @@ components:
                     description:
                       type: string
                       example: Main hall
+                  additionalProperties: false
                 borough:
                   type: string
                   description: >-
@@ -2831,6 +2928,10 @@ components:
                       type: string
                       enum:
                         - WGS84 (Decimal Degrees)
+                  required:
+                    - latitude
+                    - longitude
+                  additionalProperties: false
                 contact:
                   type: object
                   description: >-
@@ -2849,6 +2950,13 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             organizationReference:
               type: object
               properties:
@@ -2866,8 +2974,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetOrganizationsResponse:
       type: object
       properties:
@@ -2902,8 +3016,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -2913,9 +3025,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -2947,6 +3056,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3010,6 +3123,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -3042,6 +3156,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -3060,6 +3178,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 organizationsReferences:
                   type: array
                   items:
@@ -3079,15 +3204,16 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateOrganizationRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Organization
         title:
           type: object
           additionalProperties:
@@ -3138,6 +3264,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -3170,6 +3297,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -3188,6 +3319,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -3195,9 +3327,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
-        - type
         - title
+      additionalProperties: false
     CreateOrganizationResponse:
       properties:
         success:
@@ -3226,14 +3359,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchOrganizationsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchOrganizationsResponse:
       type: object
       properties:
@@ -3268,8 +3408,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -3279,9 +3417,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3313,6 +3448,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3376,6 +3515,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -3408,6 +3548,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -3426,6 +3570,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 organizationsReferences:
                   type: array
                   items:
@@ -3445,8 +3596,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateOrganizationRequest:
       type: object
       properties:
@@ -3500,6 +3656,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -3532,6 +3689,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -3550,6 +3711,8 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      additionalProperties: false
     GetAttractionsResponse:
       type: object
       properties:
@@ -3584,11 +3747,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
                     properties:
                       type:
                         type: string
@@ -3598,9 +3756,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3632,6 +3787,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3696,6 +3855,13 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 attractionsReferences:
                   type: array
                   items:
@@ -3715,15 +3881,16 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateAttractionRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Attraction
         title:
           type: object
           additionalProperties:
@@ -3782,6 +3949,7 @@ components:
                 example: https://example.com/
             required:
               - url
+            additionalProperties: false
         metadata:
           type: object
           properties:
@@ -3789,9 +3957,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
-        - type
         - title
+      additionalProperties: false
     CreateAttractionResponse:
       type: object
       properties:
@@ -3821,14 +3990,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchAttractionsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchAttractionsResponse:
       type: object
       properties:
@@ -3863,11 +4039,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
                     properties:
                       type:
                         type: string
@@ -3877,9 +4048,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3911,6 +4079,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3975,6 +4147,13 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 attractionsReferences:
                   type: array
                   items:
@@ -3994,8 +4173,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAttractionResponse:
       type: object
       properties:
@@ -4008,11 +4192,6 @@ components:
           properties:
             attraction:
               type: object
-              required:
-                - type
-                - identifier
-                - metadata
-                - title
               properties:
                 type:
                   type: string
@@ -4022,9 +4201,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -4054,6 +4230,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -4118,6 +4298,13 @@ components:
                         example: https://example.com/
                     required:
                       - url
+                    additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             attractionReference:
               type: object
               properties:
@@ -4135,8 +4322,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateAttractionRequest:
       type: object
       properties:
@@ -4198,6 +4391,8 @@ components:
                 example: https://example.com/
             required:
               - url
+            additionalProperties: false
+      additionalProperties: false
     GetLocationsResponse:
       type: object
       properties:
@@ -4232,8 +4427,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -4243,9 +4436,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -4277,6 +4467,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -4322,6 +4516,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -4354,6 +4549,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       openingStatus:
                         type: string
                         enum:
@@ -4365,12 +4564,6 @@ components:
                         items:
                           type: object
                           properties:
-                            closes:
-                              type: string
-                              description: >-
-                                The closing hour of the place or service on the
-                                given day(s) of the week.
-                              example: "22:00"
                             dayOfWeek:
                               type: string
                               enum:
@@ -4388,8 +4581,14 @@ components:
                               type: string
                               description: >-
                                 The opening hour of the place or service on the
-                                given day(s) of the week.
+                                given day of the week.
                               example: "12:00"
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day of the week.
+                              example: "22:00"
                             validFrom:
                               type: string
                               description: The date when the item becomes valid.
@@ -4399,6 +4598,11 @@ components:
                                 The date after when the item is not valid. For
                                 example the end of an offer, salary period, or a
                                 period of opening hours.
+                          required:
+                            - dayOfWeek
+                            - opens
+                            - closes
+                          additionalProperties: false
                       inLanguages:
                         type: array
                         description: List of languages this object is available in.
@@ -4431,6 +4635,7 @@ components:
                                 example: https://example.com/
                             required:
                               - url
+                            additionalProperties: false
                       manager:
                         type: object
                         properties:
@@ -4449,6 +4654,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                         description: The managing person of this location.
                       contact:
                         type: object
@@ -4466,6 +4675,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 locationsReferences:
                   type: array
                   items:
@@ -4485,15 +4701,16 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateLocationRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Location
         title:
           type: object
           additionalProperties:
@@ -4532,6 +4749,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -4564,17 +4782,15 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         openingHours:
           type: array
           items:
             type: object
             properties:
-              closes:
-                type: string
-                description: >-
-                  The closing hour of the place or service on the given day(s)
-                  of the week.
-                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -4589,9 +4805,15 @@ components:
               opens:
                 type: string
                 description: >-
-                  The opening hour of the place or service on the given day(s)
-                  of the week.
+                  The opening hour of the place or service on the given day of
+                  the week.
                 example: "12:00"
+              closes:
+                type: string
+                description: >-
+                  The closing hour of the place or service on the given day of
+                  the week.
+                example: "22:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -4600,6 +4822,11 @@ components:
                 description: >-
                   The date after when the item is not valid. For example the end
                   of an offer, salary period, or a period of opening hours.
+            required:
+              - dayOfWeek
+              - opens
+              - closes
+            additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -4628,6 +4855,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         manager:
           type: object
           properties:
@@ -4645,6 +4873,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -4663,6 +4895,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -4670,9 +4903,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
-        - type
         - title
+      additionalProperties: false
     CreateLocationResponse:
       type: object
       properties:
@@ -4702,14 +4936,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchLocationsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchLocationsResponse:
       type: object
       properties:
@@ -4744,8 +4985,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -4755,9 +4994,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -4789,6 +5025,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -4834,6 +5074,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -4866,6 +5107,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       openingStatus:
                         type: string
                         enum:
@@ -4877,12 +5122,6 @@ components:
                         items:
                           type: object
                           properties:
-                            closes:
-                              type: string
-                              description: >-
-                                The closing hour of the place or service on the
-                                given day(s) of the week.
-                              example: "22:00"
                             dayOfWeek:
                               type: string
                               enum:
@@ -4900,8 +5139,14 @@ components:
                               type: string
                               description: >-
                                 The opening hour of the place or service on the
-                                given day(s) of the week.
+                                given day of the week.
                               example: "12:00"
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day of the week.
+                              example: "22:00"
                             validFrom:
                               type: string
                               description: The date when the item becomes valid.
@@ -4911,6 +5156,11 @@ components:
                                 The date after when the item is not valid. For
                                 example the end of an offer, salary period, or a
                                 period of opening hours.
+                          required:
+                            - dayOfWeek
+                            - opens
+                            - closes
+                          additionalProperties: false
                       inLanguages:
                         type: array
                         description: List of languages this object is available in.
@@ -4943,6 +5193,7 @@ components:
                                 example: https://example.com/
                             required:
                               - url
+                            additionalProperties: false
                       manager:
                         type: object
                         properties:
@@ -4961,6 +5212,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                         description: The managing person of this location.
                       contact:
                         type: object
@@ -4978,6 +5233,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 locationsReferences:
                   type: array
                   items:
@@ -4997,8 +5259,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetLocationResponse:
       type: object
       properties:
@@ -5011,8 +5278,6 @@ components:
           properties:
             location:
               type: object
-              required:
-                - identifier
               properties:
                 type:
                   type: string
@@ -5022,9 +5287,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -5054,6 +5316,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -5099,6 +5365,7 @@ components:
                     description:
                       type: string
                       example: Main hall
+                  additionalProperties: false
                 borough:
                   type: string
                   description: >-
@@ -5131,6 +5398,10 @@ components:
                       type: string
                       enum:
                         - WGS84 (Decimal Degrees)
+                  required:
+                    - latitude
+                    - longitude
+                  additionalProperties: false
                 openingStatus:
                   type: string
                   enum:
@@ -5142,12 +5413,6 @@ components:
                   items:
                     type: object
                     properties:
-                      closes:
-                        type: string
-                        description: >-
-                          The closing hour of the place or service on the given
-                          day(s) of the week.
-                        example: "22:00"
                       dayOfWeek:
                         type: string
                         enum:
@@ -5165,8 +5430,14 @@ components:
                         type: string
                         description: >-
                           The opening hour of the place or service on the given
-                          day(s) of the week.
+                          day of the week.
                         example: "12:00"
+                      closes:
+                        type: string
+                        description: >-
+                          The closing hour of the place or service on the given
+                          day of the week.
+                        example: "22:00"
                       validFrom:
                         type: string
                         description: The date when the item becomes valid.
@@ -5176,6 +5447,11 @@ components:
                           The date after when the item is not valid. For example
                           the end of an offer, salary period, or a period of
                           opening hours.
+                    required:
+                      - dayOfWeek
+                      - opens
+                      - closes
+                    additionalProperties: false
                 inLanguages:
                   type: array
                   description: List of languages this object is available in.
@@ -5208,6 +5484,7 @@ components:
                           example: https://example.com/
                       required:
                         - url
+                      additionalProperties: false
                 manager:
                   type: object
                   properties:
@@ -5225,6 +5502,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
                   description: The managing person of this location.
                 contact:
                   type: object
@@ -5242,6 +5523,13 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             locationReference:
               type: object
               properties:
@@ -5259,8 +5547,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateLocationRequest:
       type: object
       properties:
@@ -5302,6 +5596,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -5334,6 +5629,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -5362,6 +5661,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         contact:
           type: object
           description: >-
@@ -5380,6 +5680,8 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      additionalProperties: false
     SetLocationManagerRequest:
       type: object
       properties:
@@ -5397,6 +5699,7 @@ components:
             en: concert
       required:
         - organizationIdentifier
+      additionalProperties: false
     ClaimLocationRequest:
       type: object
       properties:
@@ -5419,10 +5722,12 @@ components:
             phone:
               type: string
               description: Contact person's phone number (optional).
+          additionalProperties: false
       required:
         - organizationIdentifier
         - justification
         - contact
+      additionalProperties: false
     GetEventsResponse:
       type: object
       properties:
@@ -5457,8 +5762,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -5468,9 +5771,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -5502,6 +5802,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -5552,6 +5856,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -5617,6 +5922,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -5637,6 +5946,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -5655,6 +5968,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -5673,6 +5990,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -5704,6 +6022,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 eventsReferences:
                   type: array
                   items:
@@ -5723,15 +6047,16 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateEventRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Event
         schedule:
           type: object
           properties:
@@ -5767,6 +6092,7 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          additionalProperties: false
         title:
           type: object
           additionalProperties:
@@ -5830,6 +6156,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         attractions:
           type: array
           items:
@@ -5849,6 +6179,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         organizer:
           type: object
           properties:
@@ -5866,6 +6200,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -5884,6 +6222,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -5912,6 +6251,7 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -5919,8 +6259,13 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
-        - type
+        - schedule
+        - locations
+        - attractions
+        - organizer
+      additionalProperties: false
     CreateEventResponse:
       type: object
       properties:
@@ -5950,8 +6295,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchEventsRequest:
       type: object
       properties:
@@ -5975,6 +6326,7 @@ components:
               enum:
                 - any
                 - all
+          additionalProperties: false
         byLocationAccessibilityTags:
           type: object
           properties:
@@ -5987,8 +6339,10 @@ components:
               enum:
                 - any
                 - all
+          additionalProperties: false
         inTheFuture:
           type: boolean
+      additionalProperties: false
     SearchEventsResponse:
       type: object
       properties:
@@ -6023,8 +6377,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -6034,9 +6386,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -6068,6 +6417,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -6118,6 +6471,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -6183,6 +6537,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -6203,6 +6561,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -6221,6 +6583,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -6239,6 +6605,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -6270,6 +6637,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 eventsReferences:
                   type: array
                   items:
@@ -6289,8 +6662,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetEventResponse:
       type: object
       properties:
@@ -6303,8 +6681,6 @@ components:
           properties:
             event:
               type: object
-              required:
-                - identifier
               properties:
                 type:
                   type: string
@@ -6314,9 +6690,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -6346,6 +6719,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -6394,6 +6771,7 @@ components:
                       type: string
                       description: The time the event end, in timezone Europe/Berlin.
                       example: "22:00"
+                  additionalProperties: false
                 title:
                   type: object
                   additionalProperties:
@@ -6458,6 +6836,10 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
                 attractions:
                   type: array
                   items:
@@ -6477,6 +6859,10 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
                 organizer:
                   type: object
                   properties:
@@ -6494,6 +6880,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
                 contact:
                   type: object
                   description: >-
@@ -6512,6 +6902,7 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
                 admission:
                   type: object
                   description: Information about the admission to the event/attraction.
@@ -6540,6 +6931,12 @@ components:
                     admissionLink:
                       type: string
                       example: https://example.com/
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+              additionalProperties: false
             eventReference:
               type: object
               properties:
@@ -6557,8 +6954,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateEventRequest:
       type: object
       properties:
@@ -6624,6 +7027,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -6652,6 +7056,8 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
+          additionalProperties: false
+      additionalProperties: false
     AddEventLocationRequest:
       type: object
       properties:
@@ -6667,6 +7073,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - locationIdentifier
+      additionalProperties: false
     RemoveEventLocationRequest:
       type: object
       properties:
@@ -6674,6 +7083,7 @@ components:
           type: string
       required:
         - locationIdentifier
+      additionalProperties: false
     AddEventAttractionRequest:
       type: object
       properties:
@@ -6689,6 +7099,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - attractionIdentifier
+      additionalProperties: false
     RemoveEventAttractionRequest:
       type: object
       properties:
@@ -6696,6 +7109,7 @@ components:
           type: string
       required:
         - attractionIdentifier
+      additionalProperties: false
     SetEventOrganizerRequest:
       type: object
       properties:
@@ -6711,6 +7125,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - organizationIdentifier
+      additionalProperties: false
     RescheduleEventRequest:
       type: object
       properties:
@@ -6728,6 +7145,7 @@ components:
           type: string
         setToRescheduled:
           type: boolean
+      additionalProperties: false
     DuplicateEventResponse:
       properties:
         success:
@@ -6741,15 +7159,21 @@ components:
           properties:
             eventIdentifier:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     LoginRequest:
       type: object
       properties:
-        password:
-          type: string
         email:
           type: string
+        password:
+          type: string
+      required:
+        - email
+        - password
+      additionalProperties: false
     LoginResponse:
       type: object
       properties:
@@ -6759,10 +7183,6 @@ components:
           type: string
         data:
           type: object
-          required:
-            - accessToken
-            - expiresIn
-            - user
           properties:
             accessToken:
               type: string
@@ -6792,11 +7212,21 @@ components:
                 permissionFlags:
                   type: number
               required:
+                - type
                 - identifier
                 - email
+                - createdAt
+                - updatedAt
                 - permissionFlags
+              additionalProperties: false
+          required:
+            - accessToken
+            - expiresIn
+            - user
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetUsersResponse:
       type: object
       properties:
@@ -6853,11 +7283,16 @@ components:
                       permissionFlags:
                         type: number
                     required:
+                      - type
                       - identifier
                       - email
+                      - createdAt
+                      - updatedAt
                       - permissionFlags
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateUserRequest:
       type: object
       properties:
@@ -6872,6 +7307,7 @@ components:
       required:
         - password
         - email
+      additionalProperties: false
     EmailAlreadyInUseError:
       type: object
       properties:
@@ -6892,9 +7328,11 @@ components:
               type: string
           required:
             - code
+          additionalProperties: false
       required:
         - success
         - error
+      additionalProperties: false
     GetUserResponse:
       type: object
       properties:
@@ -6929,11 +7367,17 @@ components:
                 permissionFlags:
                   type: number
               required:
+                - type
                 - identifier
                 - email
+                - createdAt
+                - updatedAt
                 - permissionFlags
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateUserRequest:
       type: object
       properties:
@@ -6943,6 +7387,7 @@ components:
           type: string
         lastName:
           type: string
+      additionalProperties: false
     RemoveExternalLinkRequest:
       type: object
       properties:
@@ -6950,6 +7395,7 @@ components:
           type: string
       required:
         - url
+      additionalProperties: false
     CreateUserResponse:
       properties:
         success:
@@ -6963,8 +7409,10 @@ components:
           properties:
             userIdentifier:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetTagsResponse:
       type: object
       properties:
@@ -6999,9 +7447,6 @@ components:
                   metadata:
                     allOf:
                       - type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7033,6 +7478,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       - type: object
                         properties:
                           externalIDs:
@@ -7040,10 +7489,15 @@ components:
                             additionalProperties:
                               type: string
                 required:
+                  - type
                   - identifier
                   - title
+                  - metadata
+                additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetTagResponse:
       type: object
       properties:
@@ -7076,9 +7530,6 @@ components:
                 metadata:
                   allOf:
                     - type: object
-                      required:
-                        - created
-                        - updated
                       properties:
                         created:
                           type: string
@@ -7110,6 +7561,10 @@ components:
                             - en
                           items:
                             type: string
+                      required:
+                        - created
+                        - updated
+                      additionalProperties: false
                     - type: object
                       properties:
                         externalIDs:
@@ -7117,10 +7572,15 @@ components:
                           additionalProperties:
                             type: string
               required:
+                - type
                 - identifier
                 - title
+                - metadata
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateTagRequest:
       type: object
       properties:
@@ -7141,6 +7601,7 @@ components:
               type: object
       required:
         - title
+      additionalProperties: false
     CreateTagResponse:
       properties:
         success:
@@ -7174,9 +7635,6 @@ components:
                 metadata:
                   allOf:
                     - type: object
-                      required:
-                        - created
-                        - updated
                       properties:
                         created:
                           type: string
@@ -7208,6 +7666,10 @@ components:
                             - en
                           items:
                             type: string
+                      required:
+                        - created
+                        - updated
+                      additionalProperties: false
                     - type: object
                       properties:
                         externalIDs:
@@ -7215,10 +7677,15 @@ components:
                           additionalProperties:
                             type: string
               required:
+                - type
                 - identifier
                 - title
+                - metadata
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAdminAttractionResponse:
       type: object
       properties:
@@ -7231,12 +7698,6 @@ components:
           properties:
             attraction:
               type: object
-              required:
-                - type
-                - identifier
-                - metadata
-                - title
-                - events
               properties:
                 type:
                   type: string
@@ -7246,9 +7707,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -7278,6 +7736,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -7332,8 +7794,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -7343,9 +7803,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7377,6 +7834,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -7427,6 +7888,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -7492,6 +7954,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -7512,6 +7978,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -7530,6 +8000,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -7548,6 +8022,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -7579,6 +8054,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 externalLinks:
                   type: array
                   description: Links to external resources related to this object.
@@ -7593,8 +8074,18 @@ components:
                         example: https://example.com/
                     required:
                       - url
+                    additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+                - events
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAdminAttractionsResponse:
       type: object
       properties:
@@ -7631,12 +8122,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
-                      - events
                     properties:
                       type:
                         type: string
@@ -7646,9 +8131,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7680,6 +8162,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -7734,8 +8220,6 @@ components:
                         type: array
                         items:
                           type: object
-                          required:
-                            - identifier
                           properties:
                             type:
                               type: string
@@ -7745,9 +8229,6 @@ components:
                               type: string
                             metadata:
                               type: object
-                              required:
-                                - created
-                                - updated
                               properties:
                                 created:
                                   type: string
@@ -7781,6 +8262,10 @@ components:
                                     - en
                                   items:
                                     type: string
+                              required:
+                                - created
+                                - updated
+                              additionalProperties: false
                             status:
                               type: string
                               enum:
@@ -7833,6 +8318,7 @@ components:
                                     The time the event end, in timezone
                                     Europe/Berlin.
                                   example: "22:00"
+                              additionalProperties: false
                             title:
                               type: object
                               additionalProperties:
@@ -7901,6 +8387,10 @@ components:
                                     example:
                                       de: Konzert
                                       en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
                             attractions:
                               type: array
                               items:
@@ -7921,6 +8411,10 @@ components:
                                     example:
                                       de: Konzert
                                       en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
                             organizer:
                               type: object
                               properties:
@@ -7939,6 +8433,10 @@ components:
                                   example:
                                     de: Konzert
                                     en: concert
+                              required:
+                                - referenceType
+                                - referenceId
+                              additionalProperties: false
                             contact:
                               type: object
                               description: >-
@@ -7957,6 +8455,7 @@ components:
                                   type: string
                                   description: Phone number of the contact person.
                                   example: +49 30 12345678
+                              additionalProperties: false
                             admission:
                               type: object
                               description: >-
@@ -7988,6 +8487,12 @@ components:
                                 admissionLink:
                                   type: string
                                   example: https://example.com/
+                              additionalProperties: false
+                          required:
+                            - type
+                            - identifier
+                            - metadata
+                          additionalProperties: false
                       externalLinks:
                         type: array
                         description: Links to external resources related to this object.
@@ -8002,9 +8507,17 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                      - events
+                    additionalProperties: false
       required:
         - success
-        - data
+      additionalProperties: false
     TranslatableField:
       type: object
       additionalProperties:

--- a/src/components/AdminAttractionsPage/Date.tsx
+++ b/src/components/AdminAttractionsPage/Date.tsx
@@ -1,0 +1,13 @@
+import { formatDate } from "@utils/dates";
+import { useRouter } from "next/router";
+
+interface Props {
+	/** Date string in ISO format. */
+	date: string;
+}
+
+export default function Date({ date }: Props) {
+	const router = useRouter();
+	const locale = router.locale || "de";
+	return <time dateTime={date}>{formatDate(date, locale, { dateStyle: "short", timeStyle: "short" })}</time>;
+}

--- a/src/components/AdminAttractionsPage/index.tsx
+++ b/src/components/AdminAttractionsPage/index.tsx
@@ -11,6 +11,7 @@ import PageTitleHeader from "../PageTitleHeader";
 import Pagination, { PaginationType } from "../Pagination";
 import Spacer from "../Spacer";
 import Actions from "./Actions";
+import Date from "./Date";
 
 interface Props {
 	attractions: AdminAttraction[];
@@ -48,6 +49,16 @@ export default function AdminAttractionsPage(props: Props) {
 					{
 						header: t("table-header-status"),
 						getContent: (attraction) => attraction.status || "–",
+						canBeSorted: false,
+					},
+					{
+						header: t("table-header-created"),
+						getContent: (attraction) => <Date date={attraction.metadata.created} />,
+						canBeSorted: false,
+					},
+					{
+						header: t("table-header-updated"),
+						getContent: (attraction) => <Date date={attraction.metadata.updated} />,
 						canBeSorted: false,
 					},
 					{

--- a/src/components/AttractionEditor/service.ts
+++ b/src/components/AttractionEditor/service.ts
@@ -16,7 +16,6 @@ export function getInitialRequest(
 	languages: Array<string>,
 ): CreateAttractionRequest {
 	return {
-		type: "type.Attraction",
 		title: createLanguagesObject(languages, attraction?.title),
 		description: createLanguagesObject(languages, attraction?.description),
 		pleaseNote: createLanguagesObject(languages, attraction?.pleaseNote),

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -1,0 +1,21 @@
+import { formatDate } from "./dates";
+
+describe(formatDate.name, () => {
+	test("formats a string input with a German locale", () => {
+		const actual = formatDate("2023-05-10T13:37:00", "de", { dateStyle: "full", timeStyle: "medium" });
+		const expected = "Mittwoch, 10. Mai 2023 um 13:37:00";
+		expect(actual).toBe(expected);
+	});
+	test("formats a string input with an English locale", () => {
+		const actual = formatDate("2023-05-10T13:37:00", "en", { dateStyle: "full", timeStyle: "medium" });
+		const expected = "Wednesday, May 10, 2023 at 1:37:00 PM";
+		expect(actual).toBe(expected);
+	});
+	test("treats string and date inputs equally", () => {
+		const dateString = "2023-05-10T13:37:00";
+		const dateObject = new Date(dateString);
+		const actualString = formatDate(dateString, "de", { dateStyle: "full", timeStyle: "full" });
+		const actualObject = formatDate(dateObject, "de", { dateStyle: "full", timeStyle: "full" });
+		expect(actualString).toBe(actualObject);
+	});
+});

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,5 @@
+export function formatDate(date: Date | string, locale: string, options?: Intl.DateTimeFormatOptions) {
+	const dateObject = typeof date === "string" ? new Date(date) : date;
+	const format = new Intl.DateTimeFormat(locale, options);
+	return format.format(dateObject);
+}


### PR DESCRIPTION
Adjusts our frontend to the new open API schema format and shows the metadata (created and update dates) in the overview. ✨ 

![Screenshot 2023-10-04 at 18-34-56 Angebote](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/4a6329b5-c256-4502-ba07-7fd56d3284cb)
