### PR TITLE
feat: show attraction as status label instead of raw string

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -31,7 +31,10 @@
 		"table-header-updated": "Bearbeitet",
 		"table-option-edit": "Bearbeiten",
 		"table-option-delete": "Löschen",
-		"number-attractions": "{count, plural, =1 {# Angebot} other {# Angebote}}"
+		"number-attractions": "{count, plural, =1 {# Angebot} other {# Angebote}}",
+		"status-published": "Öffentlich",
+		"status-unpublished": "Entwurf",
+		"status-archived": "Archiviert"
 	},
 	"Attraction-Details": {
 		"page-title-add": "Neues Angebot erstellen",

--- a/openAPI-specs.yml
+++ b/openAPI-specs.yml
@@ -88,11 +88,13 @@ info:
     name: MIT
     url: https://github.com/technologiestiftung/kulturdaten-api/LICENSE
 servers:
-  - url: /api/
+  - url: /api
     description: This server
-  - url: http://localhost:3000/api/
+  - url: http://localhost:3000/api
     description: Local development server
-  - url: https://api-v2.kulturdaten.berlin/api/
+  - url: https://kulturdaten-api-staging.onrender.com/api
+    description: Staging server
+  - url: https://api-v2.kulturdaten.berlin/api
     description: Production server
 tags:
   - name: Discover cultural data
@@ -2191,6 +2193,7 @@ components:
         - type
         - identifier
         - metadata
+        - status
         - title
         - events
       additionalProperties: false
@@ -8135,6 +8138,7 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
                 - title
                 - events
               additionalProperties: false
@@ -8573,6 +8577,7 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
                       - events
                     additionalProperties: false

--- a/src/components/AdminAttractionDetailsPage/index.tsx
+++ b/src/components/AdminAttractionDetailsPage/index.tsx
@@ -28,7 +28,7 @@ export default function AdminAttractionDetailsPage(props: Props) {
 	return (
 		<Page metadata={{ title: pageTitle }}>
 			<PageTitle>{pageTitle}</PageTitle>
-			{attraction && <AttractionStatus status={attraction.status!} />}
+			{attraction && <AttractionStatus status={attraction.status} />}
 			<Spacer size={20} />
 			<AttractionEditor attraction={attraction} onAfterSubmit={handleAfterSubmit} />
 		</Page>

--- a/src/components/AdminAttractionDetailsPage/index.tsx
+++ b/src/components/AdminAttractionDetailsPage/index.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/router";
 import { useCallback } from "react";
 import { useTranslations } from "use-intl";
 import AttractionEditor from "../AttractionEditor";
+import AttractionStatus from "../AttractionStatus";
 import Spacer from "../Spacer";
 
 interface Props {
@@ -27,6 +28,7 @@ export default function AdminAttractionDetailsPage(props: Props) {
 	return (
 		<Page metadata={{ title: pageTitle }}>
 			<PageTitle>{pageTitle}</PageTitle>
+			{attraction && <AttractionStatus status={attraction.status!} />}
 			<Spacer size={20} />
 			<AttractionEditor attraction={attraction} onAfterSubmit={handleAfterSubmit} />
 		</Page>

--- a/src/components/AdminAttractionsPage/index.tsx
+++ b/src/components/AdminAttractionsPage/index.tsx
@@ -49,7 +49,7 @@ export default function AdminAttractionsPage(props: Props) {
 					},
 					{
 						header: t("table-header-status"),
-						getContent: (attraction) => <AttractionStatus status={attraction.status!} />,
+						getContent: (attraction) => <AttractionStatus status={attraction.status} />,
 						canBeSorted: false,
 					},
 					{

--- a/src/components/AdminAttractionsPage/index.tsx
+++ b/src/components/AdminAttractionsPage/index.tsx
@@ -5,6 +5,7 @@ import Page from "@components/Page";
 import { getLocalizedLabel } from "@utils/content";
 import { useRouter } from "next/router";
 import { useTranslations } from "use-intl";
+import AttractionStatus from "../AttractionStatus";
 import Button from "../Button";
 import ContentTable from "../ContentTable";
 import PageTitleHeader from "../PageTitleHeader";
@@ -48,7 +49,7 @@ export default function AdminAttractionsPage(props: Props) {
 					},
 					{
 						header: t("table-header-status"),
-						getContent: (attraction) => attraction.status || "–",
+						getContent: (attraction) => <AttractionStatus status={attraction.status!} />,
 						canBeSorted: false,
 					},
 					{

--- a/src/components/AttractionStatus/index.tsx
+++ b/src/components/AttractionStatus/index.tsx
@@ -1,0 +1,19 @@
+import { Attraction } from "@api/client/models/Attraction";
+import { useTranslations } from "next-intl";
+
+type Status = Attraction["status"];
+
+const i18nKeys: Record<Status, keyof IntlMessages["Attractions"]> = {
+	"attraction.published": "status-published",
+	"attraction.unpublished": "status-unpublished",
+	"attraction.archived": "status-archived",
+};
+
+interface Props {
+	status: Status;
+}
+
+export default function AttractionStatus({ status }: Props) {
+	const t = useTranslations("Attractions");
+	return <>{t(i18nKeys[status])}</>;
+}

--- a/src/components/AttractionsPage/index.tsx
+++ b/src/components/AttractionsPage/index.tsx
@@ -2,6 +2,7 @@ import { Attraction } from "@api/client/models/Attraction";
 import Page from "@components/Page";
 import { getLocalizedLabel } from "@utils/content";
 import { useTranslations } from "use-intl";
+import AttractionStatus from "../AttractionStatus";
 import ContentTable from "../ContentTable";
 import PageTitle from "../PageTitle";
 import Pagination, { PaginationType } from "../Pagination";
@@ -29,7 +30,7 @@ export default function AttractionsPage(props: Props) {
 					},
 					{
 						header: t("table-header-status"),
-						getContent: (attraction) => attraction.status || "–",
+						getContent: (attraction) => <AttractionStatus status={attraction.status} />,
 						canBeSorted: false,
 					},
 				]}


### PR DESCRIPTION
Adds a new `AttractionStatus` component to display an internationalized version of the attraction status string (instead of the raw status string, e.g. "attraction.published").

~~ℹ️ The `!` assertion of the `status` field can also be removed, once https://github.com/technologiestiftung/kulturdaten-api/pull/72 is merged.~~ Done.