### PR TITLE
chore: use readable class names in development mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+	"presets": ["next/babel"],
+	"plugins": ["@emotion"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"typescript-cookie": "^1.0.6"
 			},
 			"devDependencies": {
+				"@emotion/babel-plugin": "11.11.0",
 				"@types/node": "20.6.0",
 				"@types/react": "18.2.21",
 				"@types/react-dom": "18.2.7",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"typescript-cookie": "^1.0.6"
 	},
 	"devDependencies": {
+		"@emotion/babel-plugin": "11.11.0",
 		"@types/node": "20.6.0",
 		"@types/react": "18.2.21",
 		"@types/react-dom": "18.2.7",


### PR DESCRIPTION
Fixes #18 by adding readable class names in development mode, by adding and configuring the [Emotion babel plugin](https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin).

# Example

![Bildschirmfoto 2023-11-07 um 11 28 58](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/6f8ec4ff-a5ab-425c-b882-f747ea2795c0)

# References

- https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin
- https://nextjs.org/docs/pages/building-your-application/configuring/babel