### PR TITLE
fix: supply default timezone to next-intl

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,8 +10,9 @@ ReactModal.setAppElement(`#${APP_ELEMENT_ID}`);
 
 export default function MyApp({ Component, pageProps }: AppProps) {
 	const router = useRouter();
+	const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 	return (
-		<NextIntlClientProvider messages={pageProps.messages} locale={router.locale}>
+		<NextIntlClientProvider messages={pageProps.messages} locale={router.locale} timeZone={timeZone}>
 			<UserContextProvider>
 				<GlobalStyles />
 				<Component {...pageProps} />


### PR DESCRIPTION
After #37, we’re now getting this error message on some pages:

> IntlError: ENVIRONMENT_FALLBACK: There is no `timeZone` configured, this can lead to markup mismatches caused by environment differences. Consider adding a global default: https://next-intl-docs.vercel.app/docs/configuration#time-zone

There was still a migration step missing for the new version of next-intl: We need to provide a default timezone, as documented here: https://next-intl-docs.vercel.app/docs/usage/configuration#time-zone

This PR implements this by reading the browser’s timezone and providing it to the `NextIntlClientProvider`.