### PR TITLE
fix: keep navigation sidebar in content container

### DIFF
--- a/src/components/Page/NavigationDesktop/index.tsx
+++ b/src/components/Page/NavigationDesktop/index.tsx
@@ -1,4 +1,4 @@
-import { mediaQueries } from "@common/styleVariables";
+import { mediaQueries, widths } from "@common/styleVariables";
 import styled from "@emotion/styled";
 import Navigation from "../Navigation";
 
@@ -6,7 +6,7 @@ const DesktopContainer = styled.div({
 	display: "none",
 	position: "fixed",
 	top: 0,
-	left: 0,
+	left: `max(0, calc(50% - ${widths.maxContentWidth} / 2))`,
 	overflow: "auto",
 	[mediaQueries.m]: {
 		display: "block",


### PR DESCRIPTION
## Before

![Screenshot 2023-12-06 at 11-15-23 Benutzer innen](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/dfa554cb-5d53-455e-a5aa-4a38ef115af6)

## After

![Screenshot 2023-12-06 at 11-15-16 Benutzer innen](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/2d84250a-b056-4fd4-ab1b-f778b2177fbe)
