### PR TITLE
feat: show error message on login page when redirecting

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -4,9 +4,9 @@
 	},
 	"Navigation": {
 		"title": "kulturdaten.berlin",
-        "menu-button": "Menü",
-        "menu-modal-label": "Menü",
-        "menu-collapse": "Menü schließen",
+		"menu-button": "Menü",
+		"menu-modal-label": "Menü",
+		"menu-collapse": "Menü schließen",
 		"link-attractions": "Angebote",
 		"link-locations": "Orte",
 		"link-organizations": "Anbieter:innen",
@@ -30,6 +30,7 @@
 		"label-password": "Passwort",
 		"login-button": "Einloggen",
 		"register-button": "Neu registrieren",
+		"error-initial": "Fehler aufgetreten: {errorMessage}",
 		"error-with-code": "Login fehlgeschlagen, {code}",
 		"error-generic": "Verbindung fehlgeschlagen"
 	},

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -31,7 +31,7 @@
 		"login-button": "Einloggen",
 		"register-button": "Neu registrieren",
 		"error-initial": "Fehler aufgetreten: {errorMessage}",
-		"error-with-code": "Login fehlgeschlagen, {code}",
+		"error-with-code": "Login fehlgeschlagen ({code})",
 		"error-generic": "Verbindung fehlgeschlagen"
 	},
 	"Attractions": {

--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -1,5 +1,13 @@
+export const ERROR_URL_PARAMETER = "error";
+
 const ROUTES = {
-	login: () => "/login",
+	login: (errorMessage?: string) => {
+		const route = "/login";
+		if (errorMessage) {
+			return `${route}?${ERROR_URL_PARAMETER}=${encodeURI(errorMessage)}`;
+		}
+		return route;
+	},
 	registration: () => "/registration",
 	attractions: () => "/attractions",
 	attractionDetails: (identifier: string) => `/attractions/${identifier}`,

--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -108,8 +108,6 @@ export default function LoginPage() {
 		<PageBackground>
 			<Head metadata={{ title: t("page-title") }} />
 			<Content>
-				<ErrorMessage error={urlErrorMessage || ""} />
-				{urlErrorMessage && <Spacer size={15} />}
 				<Header>{t("page-header")}</Header>
 				<Spacer size={10} />
 				<p>{t("page-description")}</p>
@@ -148,8 +146,8 @@ export default function LoginPage() {
 							{t("register-button")}
 						</Button>
 					</Buttons>
-					{errorMessages.general && <Spacer size={15} />}
-					<ErrorMessage error={errorMessages.general || ""} />
+					{(errorMessages.general || urlErrorMessage) && <Spacer size={15} />}
+					<ErrorMessage error={errorMessages.general || urlErrorMessage || ""} />
 				</form>
 			</Content>
 		</PageBackground>

--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -1,5 +1,5 @@
 import { ApiError } from "@api/client/core/ApiError";
-import ROUTES from "@common/routes";
+import ROUTES, { ERROR_URL_PARAMETER } from "@common/routes";
 import {
 	borderRadiuses,
 	boxShadows,
@@ -18,6 +18,7 @@ import Spacer from "@components/Spacer";
 import styled from "@emotion/styled";
 import useUser from "@hooks/useUser";
 import { validateEmail } from "@services/validation";
+import { useRouter } from "next/router";
 import { FormEvent, useState } from "react";
 import { useTranslations } from "use-intl";
 
@@ -56,21 +57,16 @@ interface ErrorMessages {
 	email: string | null;
 }
 
-const emptyErrorMessages: ErrorMessages = {
+const initialErrorMessages: ErrorMessages = {
 	general: null,
 	email: null,
 };
 
-interface Props {
-	initialErrorMessage?: string | null;
-}
-
-export default function LoginPage({ initialErrorMessage }: Props) {
+export default function LoginPage() {
 	const t = useTranslations("Login");
-	const initialErrorMessages: ErrorMessages = {
-		general: initialErrorMessage ? t("error-initial", { errorMessage: initialErrorMessage }) : null,
-		email: null,
-	};
+	const router = useRouter();
+	const urlError = router.query[ERROR_URL_PARAMETER]?.toString() || null;
+	const urlErrorMessage = urlError ? t("error-initial", { errorMessage: urlError }) : null;
 	const [email, emailSet] = useState<string>("");
 	const [password, setPassword] = useState<string>("");
 	const [errorMessages, setErrorMessages] = useState<ErrorMessages>(initialErrorMessages);
@@ -86,7 +82,7 @@ export default function LoginPage({ initialErrorMessage }: Props) {
 	};
 
 	const onPasswordChange = (value: string) => {
-		setErrorMessages(emptyErrorMessages);
+		setErrorMessages(initialErrorMessages);
 		setPassword(value);
 	};
 
@@ -112,6 +108,8 @@ export default function LoginPage({ initialErrorMessage }: Props) {
 		<PageBackground>
 			<Head metadata={{ title: t("page-title") }} />
 			<Content>
+				<ErrorMessage error={urlErrorMessage || ""} />
+				{urlErrorMessage && <Spacer size={15} />}
 				<Header>{t("page-header")}</Header>
 				<Spacer size={10} />
 				<p>{t("page-description")}</p>

--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -56,13 +56,21 @@ interface ErrorMessages {
 	email: string | null;
 }
 
-const initialErrorMessages: ErrorMessages = {
+const emptyErrorMessages: ErrorMessages = {
 	general: null,
 	email: null,
 };
 
-export default function LoginPage() {
+interface Props {
+	initialErrorMessage?: string | null;
+}
+
+export default function LoginPage({ initialErrorMessage }: Props) {
 	const t = useTranslations("Login");
+	const initialErrorMessages: ErrorMessages = {
+		general: initialErrorMessage ? t("error-initial", { errorMessage: initialErrorMessage }) : null,
+		email: null,
+	};
 	const [email, emailSet] = useState<string>("");
 	const [password, setPassword] = useState<string>("");
 	const [errorMessages, setErrorMessages] = useState<ErrorMessages>(initialErrorMessages);
@@ -78,7 +86,7 @@ export default function LoginPage() {
 	};
 
 	const onPasswordChange = (value: string) => {
-		setErrorMessages(initialErrorMessages);
+		setErrorMessages(emptyErrorMessages);
 		setPassword(value);
 	};
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,11 +1,9 @@
-import { ERROR_URL_PARAMETER } from "@common/routes";
 import LoginPage from "@components/LoginPage";
 import { loadMessages } from "@services/i18n";
-import { GetServerSideProps } from "next";
+import { GetStaticProps } from "next";
 
-export const getServerSideProps: GetServerSideProps = async (context) => ({
+export const getStaticProps: GetStaticProps = async (context) => ({
 	props: {
-		initialErrorMessage: context.query?.[ERROR_URL_PARAMETER] || null,
 		messages: await loadMessages(context.locale!),
 	},
 });

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,9 +1,11 @@
+import { ERROR_URL_PARAMETER } from "@common/routes";
 import LoginPage from "@components/LoginPage";
 import { loadMessages } from "@services/i18n";
-import { GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 
-export const getStaticProps: GetStaticProps = async (context) => ({
+export const getServerSideProps: GetServerSideProps = async (context) => ({
 	props: {
+		initialErrorMessage: context.query?.[ERROR_URL_PARAMETER] || null,
 		messages: await loadMessages(context.locale!),
 	},
 });


### PR DESCRIPTION
When redirecting to the login page due to an exception, we currently do not show _why_ there was a redirect. This PR reads the API error from the exception and displays some basic info on the login page to explain the redirect a bit. It looks like this:

![Bildschirmfoto 2023-12-06 um 11 59 17](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/d5c9fa80-1b54-456c-979b-8d13110fa576)
