### PR TITLE
refactor: simplify withApiClientAndPagination() function and usages

### DIFF
--- a/src/pages/attractions/[identifier].tsx
+++ b/src/pages/attractions/[identifier].tsx
@@ -5,14 +5,13 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof AttractionDetailsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient }) => {
 	const identifier = context.query.identifier as string;
 	const response = await apiClient.admin.getAdminAttractions1(identifier);
 	const attraction = response.data!.attraction!;
 	return {
 		props: {
 			attraction,
-			messages,
 		},
 	};
 });

--- a/src/pages/attractions/[identifier].tsx
+++ b/src/pages/attractions/[identifier].tsx
@@ -1,24 +1,20 @@
-import { AdminAttraction } from "@api/client/models/AdminAttraction";
 import AttractionDetailsPage from "@components/pages/AttractionDetailsPage";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	attraction: AdminAttraction;
-}
+type Props = ComponentProps<typeof AttractionDetailsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ apiClient, messages }) => {
-		const identifier = context.query.identifier as string;
-		const response = await apiClient.admin.getAdminAttractions1(identifier);
-		const attraction = response.data!.attraction!;
-		return {
-			props: {
-				attraction,
-				messages,
-			},
-		};
-	});
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+	const identifier = context.query.identifier as string;
+	const response = await apiClient.admin.getAdminAttractions1(identifier);
+	const attraction = response.data!.attraction!;
+	return {
+		props: {
+			attraction,
+			messages,
+		},
+	};
+});
 
 export default withAuth(AttractionDetailsPage);

--- a/src/pages/attractions/create.tsx
+++ b/src/pages/attractions/create.tsx
@@ -1,18 +1,15 @@
 import AttractionDetailsPage from "@components/pages/AttractionDetailsPage";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	attraction: null;
-}
+type Props = ComponentProps<typeof AttractionDetailsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ messages }) => ({
-		props: {
-			attraction: null,
-			messages,
-		},
-	}));
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ messages }) => ({
+	props: {
+		attraction: null,
+		messages,
+	},
+}));
 
 export default withAuth(AttractionDetailsPage);

--- a/src/pages/attractions/create.tsx
+++ b/src/pages/attractions/create.tsx
@@ -5,10 +5,9 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof AttractionDetailsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ messages }) => ({
+export const getServerSideProps = withApiClientAndPagination<Props>(async () => ({
 	props: {
 		attraction: null,
-		messages,
 	},
 }));
 

--- a/src/pages/attractions/index.tsx
+++ b/src/pages/attractions/index.tsx
@@ -1,25 +1,21 @@
-import { AdminAttraction } from "@api/client/models/AdminAttraction";
 import AttractionsPage from "@components/pages/AttractionsPage";
 import { getPaginationProps } from "@services/pagination";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	attractions: AdminAttraction[];
-}
+type Props = ComponentProps<typeof AttractionsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ apiClient, page, pageSize, messages }) => {
-		const response = await apiClient.admin.getAdminAttractions(page, pageSize);
-		const data = response.data!;
-		return {
-			props: {
-				attractions: data.attractions || [],
-				pagination: getPaginationProps(data),
-				messages,
-			},
-		};
-	});
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, page, pageSize, messages }) => {
+	const response = await apiClient.admin.getAdminAttractions(page, pageSize);
+	const data = response.data!;
+	return {
+		props: {
+			attractions: data.attractions || [],
+			pagination: getPaginationProps(data),
+			messages,
+		},
+	};
+});
 
 export default withAuth(AttractionsPage);

--- a/src/pages/attractions/index.tsx
+++ b/src/pages/attractions/index.tsx
@@ -6,14 +6,13 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof AttractionsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, page, pageSize, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, page, pageSize }) => {
 	const response = await apiClient.admin.getAdminAttractions(page, pageSize);
 	const data = response.data!;
 	return {
 		props: {
 			attractions: data.attractions || [],
 			pagination: getPaginationProps(data),
-			messages,
 		},
 	};
 });

--- a/src/pages/locations/[identifier].tsx
+++ b/src/pages/locations/[identifier].tsx
@@ -1,24 +1,20 @@
-import { Location } from "@api/client/models/Location";
 import LocationDetailsPage from "@components/pages/LocationDetailsPage";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	location: Location;
-}
+type Props = ComponentProps<typeof LocationDetailsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ apiClient, messages }) => {
-		const identifier = context.query.identifier as string;
-		const response = await apiClient.discoverCulturalData.getLocations1(identifier);
-		const location = response.data!.location!;
-		return {
-			props: {
-				location,
-				messages,
-			},
-		};
-	});
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+	const identifier = context.query.identifier as string;
+	const response = await apiClient.discoverCulturalData.getLocations1(identifier);
+	const location = response.data!.location!;
+	return {
+		props: {
+			location,
+			messages,
+		},
+	};
+});
 
 export default withAuth(LocationDetailsPage);

--- a/src/pages/locations/[identifier].tsx
+++ b/src/pages/locations/[identifier].tsx
@@ -5,14 +5,13 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof LocationDetailsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient }) => {
 	const identifier = context.query.identifier as string;
 	const response = await apiClient.discoverCulturalData.getLocations1(identifier);
 	const location = response.data!.location!;
 	return {
 		props: {
 			location,
-			messages,
 		},
 	};
 });

--- a/src/pages/organizations/[identifier].tsx
+++ b/src/pages/organizations/[identifier].tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof OrganizationDetailsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient }) => {
 	const identifier = context.query.identifier as string;
 	const organizationResponse = await apiClient.discoverCulturalData.getOrganizations1(identifier);
 	const tagsResponse = await apiClient.discoverCulturalData.getTagsOrganizations();
@@ -13,7 +13,6 @@ export const getServerSideProps = withApiClientAndPagination<Props>(async ({ con
 		props: {
 			organization: organizationResponse.data!.organization!,
 			tags: tagsResponse.data!.tags!,
-			messages,
 		},
 	};
 });

--- a/src/pages/organizations/[identifier].tsx
+++ b/src/pages/organizations/[identifier].tsx
@@ -1,27 +1,21 @@
-import { Organization } from "@api/client/models/Organization";
-import { Tag } from "@common/types";
 import OrganizationDetailsPage from "@components/pages/OrganizationDetailsPage";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	organization: Organization;
-	tags: Tag[];
-}
+type Props = ComponentProps<typeof OrganizationDetailsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ apiClient, messages }) => {
-		const identifier = context.query.identifier as string;
-		const organizationResponse = await apiClient.discoverCulturalData.getOrganizations1(identifier);
-		const tagsResponse = await apiClient.discoverCulturalData.getTagsOrganizations();
-		return {
-			props: {
-				organization: organizationResponse.data!.organization!,
-				tags: tagsResponse.data!.tags!,
-				messages,
-			},
-		};
-	});
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ context, apiClient, messages }) => {
+	const identifier = context.query.identifier as string;
+	const organizationResponse = await apiClient.discoverCulturalData.getOrganizations1(identifier);
+	const tagsResponse = await apiClient.discoverCulturalData.getTagsOrganizations();
+	return {
+		props: {
+			organization: organizationResponse.data!.organization!,
+			tags: tagsResponse.data!.tags!,
+			messages,
+		},
+	};
+});
 
 export default withAuth(OrganizationDetailsPage);

--- a/src/pages/organizations/create.tsx
+++ b/src/pages/organizations/create.tsx
@@ -5,13 +5,12 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof OrganizationDetailsPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient }) => {
 	const tagsResponse = await apiClient.discoverCulturalData.getTagsOrganizations();
 	return {
 		props: {
 			organization: null,
 			tags: tagsResponse.data!.tags!,
-			messages,
 		},
 	};
 });

--- a/src/pages/organizations/create.tsx
+++ b/src/pages/organizations/create.tsx
@@ -1,18 +1,19 @@
 import OrganizationDetailsPage from "@components/pages/OrganizationDetailsPage";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	organization: null;
-}
+type Props = ComponentProps<typeof OrganizationDetailsPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ messages }) => ({
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, messages }) => {
+	const tagsResponse = await apiClient.discoverCulturalData.getTagsOrganizations();
+	return {
 		props: {
 			organization: null,
+			tags: tagsResponse.data!.tags!,
 			messages,
 		},
-	}));
+	};
+});
 
 export default withAuth(OrganizationDetailsPage);

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -6,7 +6,7 @@ import { ComponentProps } from "react";
 
 type Props = ComponentProps<typeof UsersPage>;
 
-export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, accessToken, messages }) => {
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, accessToken }) => {
 	const decodedAccessToken = decodeAccessToken(accessToken);
 	const response = await apiClient.manageYourOrganizationData.getOrganizationsMemberships(
 		decodedAccessToken.organizationIdentifier,
@@ -15,7 +15,6 @@ export const getServerSideProps = withApiClientAndPagination<Props>(async ({ api
 	return {
 		props: {
 			memberships: data.memberships || [],
-			messages,
 		},
 	};
 });

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -1,27 +1,23 @@
-import { Membership } from "@common/types";
 import UsersPage from "@components/pages/UsersPage";
 import { decodeAccessToken } from "@services/auth";
 import withApiClientAndPagination from "@services/withApiClientAndPagination";
 import withAuth from "@services/withAuth";
-import { GetServerSideProps } from "next";
+import { ComponentProps } from "react";
 
-interface Props {
-	memberships: Membership[];
-}
+type Props = ComponentProps<typeof UsersPage>;
 
-export const getServerSideProps: GetServerSideProps<Props> = (context) =>
-	withApiClientAndPagination<Props>(context)(async ({ apiClient, accessToken, messages }) => {
-		const decodedAccessToken = decodeAccessToken(accessToken);
-		const response = await apiClient.manageYourOrganizationData.getOrganizationsMemberships(
-			decodedAccessToken.organizationIdentifier,
-		);
-		const data = response.data!;
-		return {
-			props: {
-				memberships: data.memberships || [],
-				messages,
-			},
-		};
-	});
+export const getServerSideProps = withApiClientAndPagination<Props>(async ({ apiClient, accessToken, messages }) => {
+	const decodedAccessToken = decodeAccessToken(accessToken);
+	const response = await apiClient.manageYourOrganizationData.getOrganizationsMemberships(
+		decodedAccessToken.organizationIdentifier,
+	);
+	const data = response.data!;
+	return {
+		props: {
+			memberships: data.memberships || [],
+			messages,
+		},
+	};
+});
 
 export default withAuth(UsersPage);

--- a/src/services/withApiClientAndPagination.tsx
+++ b/src/services/withApiClientAndPagination.tsx
@@ -5,7 +5,7 @@ import ROUTES from "@common/routes";
 import { decodeAccessToken, getAccessTokenFromContext } from "@services/auth";
 import { loadMessages } from "@services/i18n";
 import { getPaginationFromQuery } from "@services/pagination";
-import { GetServerSidePropsContext, GetServerSidePropsResult, Redirect } from "next";
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 
 type ServerSideFunction<Props> = (parameters: {
 	context: GetServerSidePropsContext;
@@ -27,13 +27,9 @@ export default function withApiClientAndPagination<Props>(serverSideFunction: Se
 	return async function (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<Props>> {
 		const accessToken = getAccessTokenFromContext(context);
 		if (!accessToken || !isTokenValid(accessToken)) {
-			const loginRedirect: { redirect: Redirect } = {
-				redirect: {
-					destination: ROUTES.login(),
-					permanent: false,
-				},
+			return {
+				redirect: { destination: ROUTES.login(), permanent: false },
 			};
-			return loginRedirect;
 		}
 		const apiClient = createAuthorizedClient(accessToken);
 		const { page, pageSize } = getPaginationFromQuery(context.query);
@@ -60,13 +56,9 @@ export default function withApiClientAndPagination<Props>(serverSideFunction: Se
 		} catch (error) {
 			const apiError = error as ApiError;
 			const errorMessage = `${apiError.message} (${apiError.status})`;
-			const loginRedirect: { redirect: Redirect } = {
-				redirect: {
-					destination: ROUTES.login(errorMessage),
-					permanent: false,
-				},
+			return {
+				redirect: { destination: ROUTES.login(errorMessage), permanent: false },
 			};
-			return loginRedirect;
 		}
 	};
 }

--- a/src/services/withAuth.tsx
+++ b/src/services/withAuth.tsx
@@ -20,6 +20,7 @@ export default function withAuth<Props>(wrappedComponent: ComponentType<Props>) 
 		}, [router]);
 
 		if (loading) {
+			// TODO: Style this loading state a bit more.
 			return <div>Loading...</div>;
 		}
 		return <WrappedComponent {...props} />;


### PR DESCRIPTION
This simplifies the `withApiClientAndPagination()` wrapper function, so its usage is easier and the `context` parameter does not need to be manually handed around anymore.

Also:

- The i18n `messages` prop is now automatically added within `withApiClientAndPagination()`
- The `Props` type is automatically generated through the imported components’ props – this way I also found a bug (the `tags` were not being loaded on the `/organizations/create` page)