### PR TITLE
fix: add SameSite attribute in cookie setup

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -10,6 +10,7 @@ export function storeAccessToken(accessToken: string) {
 		// TODO: Calculate expiry date via loginResponseData.expiresIn.
 		// expires: loginResponseData.expiresIn ? new Date(loginResponseData.expiresIn) : undefined,
 		path: "/",
+		sameSite: "Strict",
 	});
 }
 
@@ -18,7 +19,9 @@ export function getAccessToken() {
 }
 
 export function clearAccessToken() {
-	removeCookie(ACCESS_TOKEN_COOKIE_NAME);
+	removeCookie(ACCESS_TOKEN_COOKIE_NAME, {
+		sameSite: "Strict",
+	});
 }
 
 export function getAccessTokenFromContext(context: GetServerSidePropsContext) {


### PR DESCRIPTION
Adds a value for [sameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) when setting and deleting the accesss token cookie, to get rid of the browser warning about the missing attribute.

This used to be the warning (in Firefox):

![Bildschirmfoto 2023-12-07 um 15 21 39](https://github.com/technologiestiftung/kulturdaten-webapp/assets/6429568/ddd804e1-a754-4e07-b678-690e1eb75017)